### PR TITLE
feat(workspace): white-label branding + subdomains (multi-domain Phase 1)

### DIFF
--- a/backend/app-service/src/rpc/workspaces.py
+++ b/backend/app-service/src/rpc/workspaces.py
@@ -29,6 +29,7 @@ from shared.rbac import (
 )
 from shared.repository import AuthUserRepository
 from shared.rpc.identity import ensure_workspace_permission
+from shared.tenancy.hostnames import subdomain_from_host
 from src import models, schemas
 from src.core import config, db
 from src.rpc import _common as c
@@ -154,6 +155,30 @@ def register(broker: Any, logger: Any) -> None:
             return schemas.WorkspaceRead.model_validate(workspace, from_attributes=True)
 
         return await c.envelope(logger, "workspaces.get", op, session_factory=_SF)
+
+    @broker.subscriber("rpc.app.workspaces.by_host")
+    async def by_host(data: dict, msg: RabbitMessage) -> dict:
+        """Resolve a request host to its workspace: ``{workspace_id, slug}``.
+
+        Public (no auth). Phase 1 matches only the platform-zone subdomain
+        (``subdomain_from_host``) against ``Workspace.subdomain``; custom
+        domains are Phase 2. Returns ``data: None`` when the host is missing,
+        not a platform-zone subdomain, or matches no workspace.
+        """
+
+        async def op(session: Any) -> Any:
+            host = c.q1(data, "host", str, None)
+            if not host:
+                return None
+            label = subdomain_from_host(host)
+            if label is None:
+                return None
+            workspace = await workspace_service.get_by_subdomain(session, label)
+            if workspace is None:
+                return None
+            return {"workspace_id": workspace.id, "slug": workspace.slug}
+
+        return await c.envelope(logger, "workspaces.by_host", op, session_factory=_SF)
 
     # --- create (superuser) -------------------------------------------------
     @broker.subscriber("rpc.app.workspaces.create")

--- a/backend/app-service/src/schemas/workspace.py
+++ b/backend/app-service/src/schemas/workspace.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from shared.tenancy.hostnames import validate_subdomain_label
 from src.schemas.base import BaseRead
 from src.schemas.division_grid import DivisionGridVersionRead
 
@@ -30,6 +31,9 @@ class WorkspaceRead(BaseRead):
     brand_secondary: str | None = None
     brand_background: str | None = None
     brand_surface: str | None = None
+    subdomain: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
     default_division_grid_version_id: int | None
     default_division_grid_version: DivisionGridVersionRead | None = None
 
@@ -52,7 +56,17 @@ class WorkspaceUpdate(BaseModel):
     brand_secondary: str | None = Field(default=None, pattern=_HEX_COLOR)
     brand_background: str | None = Field(default=None, pattern=_HEX_COLOR)
     brand_surface: str | None = Field(default=None, pattern=_HEX_COLOR)
+    subdomain: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
     default_division_grid_version_id: int | None = None
+
+    @field_validator("subdomain")
+    @classmethod
+    def _validate_subdomain(cls, value: str | None) -> str | None:
+        if value is None or value == "":
+            return None
+        return validate_subdomain_label(value)
 
 
 class WorkspaceMemberRoleRead(BaseModel):

--- a/backend/app-service/src/schemas/workspace.py
+++ b/backend/app-service/src/schemas/workspace.py
@@ -3,6 +3,10 @@ from pydantic import BaseModel, Field
 from src.schemas.base import BaseRead
 from src.schemas.division_grid import DivisionGridVersionRead
 
+# 6-digit hex colour (#RRGGBB) — the format the frontend colour pickers emit and
+# the branding derive util consumes.
+_HEX_COLOR = r"^#[0-9a-fA-F]{6}$"
+
 __all__ = (
     "WorkspaceRead",
     "WorkspaceCreate",
@@ -21,6 +25,11 @@ class WorkspaceRead(BaseRead):
     description: str | None
     icon_url: str | None
     is_active: bool
+    branding_enabled: bool = False
+    brand_primary: str | None = None
+    brand_secondary: str | None = None
+    brand_background: str | None = None
+    brand_surface: str | None = None
     default_division_grid_version_id: int | None
     default_division_grid_version: DivisionGridVersionRead | None = None
 
@@ -38,6 +47,11 @@ class WorkspaceUpdate(BaseModel):
     description: str | None = None
     icon_url: str | None = None
     is_active: bool | None = None
+    branding_enabled: bool | None = None
+    brand_primary: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_secondary: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_background: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_surface: str | None = Field(default=None, pattern=_HEX_COLOR)
     default_division_grid_version_id: int | None = None
 
 

--- a/backend/app-service/src/services/workspace/service.py
+++ b/backend/app-service/src/services/workspace/service.py
@@ -37,6 +37,10 @@ async def get_by_slug(session: AsyncSession, slug: str) -> models.Workspace | No
     return await _workspace_repo.get_by_slug(session, slug)
 
 
+async def get_by_subdomain(session: AsyncSession, subdomain: str) -> models.Workspace | None:
+    return await _workspace_repo.get_by_subdomain(session, subdomain)
+
+
 async def get_all(session: AsyncSession) -> typing.Sequence[models.Workspace]:
     return await _workspace_repo.list_ordered(session)
 

--- a/backend/app-service/tests/api/test_workspaces_by_host.py
+++ b/backend/app-service/tests/api/test_workspaces_by_host.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.rpc import workspaces as workspaces_rpc
+
+
+@pytest.mark.integration
+def test_by_host_unknown_returns_null(rpc):
+    harness = rpc  # session-scoped harness (skips if DB unreachable)
+    harness.register(workspaces_rpc)
+    res = harness.call_sync(
+        "rpc.app.workspaces.by_host",
+        {"query": {"host": ["nope.owt.craazzzyyfoxx.me"]}},
+    )
+    assert res["ok"] is True
+    assert res["data"] is None
+
+
+@pytest.mark.integration
+def test_by_host_missing_host_returns_null(rpc):
+    harness = rpc
+    harness.register(workspaces_rpc)
+    res = harness.call_sync("rpc.app.workspaces.by_host", {"query": {}})
+    assert res["ok"] is True
+    assert res["data"] is None
+
+
+@pytest.mark.integration
+def test_by_host_non_platform_zone_returns_null(rpc):
+    harness = rpc
+    harness.register(workspaces_rpc)
+    res = harness.call_sync(
+        "rpc.app.workspaces.by_host",
+        {"query": {"host": ["example.com"]}},
+    )
+    assert res["ok"] is True
+    assert res["data"] is None

--- a/backend/app-service/tests/test_hostnames.py
+++ b/backend/app-service/tests/test_hostnames.py
@@ -39,3 +39,17 @@ def test_subdomain_from_host_ignores_apex_www_and_foreign():
     assert subdomain_from_host("a.b.owt.craazzzyyfoxx.me") is None  # multi-segment
     assert subdomain_from_host("evil.com") is None
     assert subdomain_from_host("team-a.owt.craazzzyyfoxx.me:443") == "team-a"  # port stripped
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "te$t.owt.craazzzyyfoxx.me",
+        "-team.owt.craazzzyyfoxx.me",
+        ("a" * 64) + ".owt.craazzzyyfoxx.me",
+        "api.owt.craazzzyyfoxx.me",
+        "admin.owt.craazzzyyfoxx.me",
+    ],
+)
+def test_subdomain_from_host_rejects_invalid_or_reserved(host):
+    assert subdomain_from_host(host) is None

--- a/backend/app-service/tests/test_hostnames.py
+++ b/backend/app-service/tests/test_hostnames.py
@@ -1,0 +1,41 @@
+import pytest
+
+from shared.tenancy.hostnames import (
+    PLATFORM_ZONE,
+    subdomain_from_host,
+    validate_subdomain_label,
+)
+
+
+def test_platform_zone():
+    assert PLATFORM_ZONE == "owt.craazzzyyfoxx.me"
+
+
+@pytest.mark.parametrize("label", ["team-a", "owcs", "a", "x1y2"])
+def test_validate_accepts_valid_labels(label):
+    assert validate_subdomain_label(label.upper()) == label  # normalizes case
+
+
+@pytest.mark.parametrize("bad", ["team_a", "-team", "te am", "", "a" * 64, "café"])
+def test_validate_rejects_malformed(bad):
+    with pytest.raises(ValueError):
+        validate_subdomain_label(bad)
+
+
+@pytest.mark.parametrize("reserved", ["www", "api", "auth", "admin", "ws"])
+def test_validate_rejects_reserved(reserved):
+    with pytest.raises(ValueError):
+        validate_subdomain_label(reserved)
+
+
+def test_subdomain_from_host_extracts_label():
+    assert subdomain_from_host("team-a.owt.craazzzyyfoxx.me") == "team-a"
+    assert subdomain_from_host("TEAM-A.owt.craazzzyyfoxx.me") == "team-a"
+
+
+def test_subdomain_from_host_ignores_apex_www_and_foreign():
+    assert subdomain_from_host("owt.craazzzyyfoxx.me") is None
+    assert subdomain_from_host("www.owt.craazzzyyfoxx.me") is None
+    assert subdomain_from_host("a.b.owt.craazzzyyfoxx.me") is None  # multi-segment
+    assert subdomain_from_host("evil.com") is None
+    assert subdomain_from_host("team-a.owt.craazzzyyfoxx.me:443") == "team-a"  # port stripped

--- a/backend/app-service/tests/test_workspace_branding_schema.py
+++ b/backend/app-service/tests/test_workspace_branding_schema.py
@@ -1,0 +1,53 @@
+"""Unit tests for workspace branding schema validation (no DB required)."""
+
+import pytest
+from pydantic import ValidationError
+
+from src import schemas
+
+
+def test_update_accepts_valid_hex_and_toggle():
+    model = schemas.WorkspaceUpdate(
+        branding_enabled=True,
+        brand_primary="#14b8a6",
+        brand_secondary="#8B5CF6",
+        brand_background="#0b1220",
+        brand_surface="#111a2b",
+    )
+    assert model.brand_primary == "#14b8a6"
+    assert model.brand_secondary == "#8B5CF6"
+    assert model.branding_enabled is True
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["14b8a6", "#14b8a", "#xyzxyz", "teal", "#14b8a6ff", "rgb(0,0,0)"],
+)
+def test_update_rejects_malformed_hex(bad):
+    with pytest.raises(ValidationError):
+        schemas.WorkspaceUpdate(brand_primary=bad)
+
+
+def test_update_omits_unset_branding():
+    model = schemas.WorkspaceUpdate()
+    assert model.brand_primary is None
+    # exclude_unset is what _svc_update passes to the CRUD engine — nothing set
+    # means nothing is written.
+    assert model.model_dump(exclude_unset=True) == {}
+
+
+def test_update_allows_explicit_none_to_clear():
+    model = schemas.WorkspaceUpdate(brand_primary=None)
+    assert model.model_dump(exclude_unset=True) == {"brand_primary": None}
+
+
+def test_read_exposes_branding_fields():
+    fields = schemas.WorkspaceRead.model_fields
+    for name in (
+        "branding_enabled",
+        "brand_primary",
+        "brand_secondary",
+        "brand_background",
+        "brand_surface",
+    ):
+        assert name in fields

--- a/backend/app-service/tests/test_workspace_branding_schema.py
+++ b/backend/app-service/tests/test_workspace_branding_schema.py
@@ -51,3 +51,20 @@ def test_read_exposes_branding_fields():
         "brand_surface",
     ):
         assert name in fields
+
+
+def test_update_accepts_valid_subdomain():
+    model = schemas.WorkspaceUpdate(subdomain="Team-A")
+    assert model.subdomain == "team-a"  # normalized
+
+
+@pytest.mark.parametrize("bad", ["team_a", "www", "-x", "a" * 64])
+def test_update_rejects_bad_subdomain(bad):
+    with pytest.raises(ValidationError):
+        schemas.WorkspaceUpdate(subdomain=bad)
+
+
+def test_read_exposes_domain_seo_fields():
+    fields = schemas.WorkspaceRead.model_fields
+    for name in ("subdomain", "seo_title", "seo_description"):
+        assert name in fields

--- a/backend/env/auth.env.example
+++ b/backend/env/auth.env.example
@@ -24,6 +24,6 @@ BATTLENET_CLIENT_ID=your_battlenet_client_id
 BATTLENET_CLIENT_SECRET=your_battlenet_client_secret
 BATTLENET_REGION=eu
 
-OAUTH_REDIRECT=your_shared_oauth_redirect
+OAUTH_REDIRECT=https://owt.craazzzyyfoxx.me/auth/callback
 
 OAUTH_STATE_EXPIRE_MINUTES=10

--- a/backend/env/common.env.example
+++ b/backend/env/common.env.example
@@ -3,6 +3,7 @@ PROJECT_URL=http://localhost
 REDIS_URL=redis://redis:6379
 RABBITMQ_URL=amqp://admin:secure_password@rabbitmq:5672
 CORS_ORIGINS=["http://localhost", "http://localhost:3000"]
+GATEWAY_WS_ALLOWED_ORIGINS=https://owt.craazzzyyfoxx.me,https://*.owt.craazzzyyfoxx.me
 
 # Auth Service Configuration (for inter-service communication)
 AUTH_SERVICE_URL=http://auth:8001

--- a/backend/identity-service/serve.py
+++ b/backend/identity-service/serve.py
@@ -357,8 +357,11 @@ async def rpc_oauth_url(data: dict, msg: RabbitMessage) -> dict:
         redirect = "/"
     if not action or not isinstance(action, str):
         return rpc_error("bad_request", "action is required")
+    csrf = data.get("csrf")
+    if not csrf or not isinstance(csrf, str):
+        return rpc_error("bad_request", "csrf is required")
     try:
-        result = oauth_flows.get_url(provider, origin=origin, redirect=redirect, action=action)
+        result = oauth_flows.get_url(provider, origin=origin, redirect=redirect, action=action, csrf=csrf)
         return rpc_ok(result.model_dump(mode="json"))
     except HTTPException as exc:
         return rpc_error(status_to_code(exc.status_code), str(exc.detail))
@@ -376,7 +379,13 @@ async def rpc_oauth_callback(data: dict, msg: RabbitMessage) -> dict:
     try:
         async with db.async_session_maker() as session:
             token = await oauth_flows.callback(
-                session, provider, code, state, data.get("user_agent"), data.get("ip_address")
+                session,
+                provider,
+                code,
+                state,
+                data.get("user_agent"),
+                data.get("ip_address"),
+                data.get("csrf"),
             )
         return rpc_ok(token.model_dump(mode="json"))
     except HTTPException as exc:
@@ -394,7 +403,7 @@ async def rpc_oauth_link(data: dict, msg: RabbitMessage) -> dict:
     async def op(session: Any, user: Any) -> dict:
         if not (provider and code and state):
             raise HTTPException(status_code=422, detail="provider, code and state are required")
-        return await oauth_flows.link(session, user, provider, code, state)
+        return await oauth_flows.link(session, user, provider, code, state, data.get("csrf"))
 
     return await _with_active_user(data.get("access_token"), op)
 

--- a/backend/identity-service/serve.py
+++ b/backend/identity-service/serve.py
@@ -346,11 +346,20 @@ async def rpc_oauth_providers(data: dict, msg: RabbitMessage) -> dict:
 
 @broker.subscriber("rpc.identity.oauth_url")
 async def rpc_oauth_url(data: dict, msg: RabbitMessage) -> dict:
-    provider = (data or {}).get("provider")
+    data = data or {}
+    provider = data.get("provider")
     if not provider or not isinstance(provider, str):
         return rpc_error("bad_request", "provider is required")
+    origin, redirect, action = data.get("origin"), data.get("redirect"), data.get("action")
+    if not origin or not isinstance(origin, str):
+        return rpc_error("bad_request", "origin is required")
+    if not isinstance(redirect, str) or not redirect:
+        redirect = "/"
+    if not action or not isinstance(action, str):
+        return rpc_error("bad_request", "action is required")
     try:
-        return rpc_ok(oauth_flows.get_url(provider).model_dump(mode="json"))
+        result = oauth_flows.get_url(provider, origin=origin, redirect=redirect, action=action)
+        return rpc_ok(result.model_dump(mode="json"))
     except HTTPException as exc:
         return rpc_error(status_to_code(exc.status_code), str(exc.detail))
     except Exception:  # pragma: no cover - defensive worker guard

--- a/backend/identity-service/src/core/config.py
+++ b/backend/identity-service/src/core/config.py
@@ -73,7 +73,14 @@ class Settings(BaseServiceSettings):
     BATTLENET_CLIENT_SECRET: str | None = None
     BATTLENET_REGION: str = "eu"
 
-    # Shared frontend OAuth callback
+    # The ONE fixed OAuth callback URL registered with every provider (Discord,
+    # Twitch, Battle.net). Always the platform apex -- NEVER derived from the
+    # request's originating host/subdomain, since providers only allow a
+    # static, pre-registered redirect_uri. The originating host, post-auth
+    # redirect path, and action ("login"/"link") instead travel inside the
+    # signed ``state`` (see ``oauth_service.encode_state``/``verify_state``),
+    # so the callback can send the user back to the tenant subdomain that
+    # started the flow.
     OAUTH_REDIRECT: str | None = None
     OAUTH_STATE_EXPIRE_MINUTES: int = 10
 

--- a/backend/identity-service/src/schemas/__init__.py
+++ b/backend/identity-service/src/schemas/__init__.py
@@ -32,6 +32,7 @@ from .auth import (
 from .oauth import (
     LinkedPlayer,
     OAuthCallbackRequest,
+    OAuthCallbackResult,
     OAuthConnectionAdminRead,
     OAuthConnectionListParams,
     OAuthConnectionListQueryParams,
@@ -99,6 +100,7 @@ __all__ = [
     "OAuthProviderAvailability",
     "OAuthURL",
     "OAuthCallbackRequest",
+    "OAuthCallbackResult",
     "OAuthUserInfo",
     "OAuthConnectionRead",
     "OAuthConnectionAdminRead",

--- a/backend/identity-service/src/schemas/oauth.py
+++ b/backend/identity-service/src/schemas/oauth.py
@@ -11,11 +11,14 @@ from pydantic import BaseModel, Field
 
 from shared.core import pagination
 
+from .auth import Token
+
 __all__ = (
     "OAuthProvider",
     "OAuthProviderAvailability",
     "OAuthURL",
     "OAuthCallbackRequest",
+    "OAuthCallbackResult",
     "OAuthUserInfo",
     "OAuthConnectionRead",
     "OAuthConnectionAdminRead",
@@ -57,6 +60,17 @@ class OAuthCallbackRequest(BaseModel):
 
     code: str
     state: str
+
+
+class OAuthCallbackResult(Token):
+    """OAuth callback response: the session token plus the decoded, verified
+    state fields the frontend needs to redirect the user back to the tenant
+    subdomain that started the flow (the callback itself always lands on the
+    one fixed apex callback URL, never on ``origin``)."""
+
+    origin: str
+    redirect: str
+    action: str
 
 
 class OAuthUserInfo(BaseModel):

--- a/backend/identity-service/src/services/oauth_flows.py
+++ b/backend/identity-service/src/services/oauth_flows.py
@@ -104,7 +104,7 @@ def _verify_csrf_binding(payload: StatePayload, csrf: str | None) -> None:
     module uses -- never distinguished in the response, and the raw token is
     never logged (only compared, in constant time).
     """
-    if not csrf:
+    if not isinstance(csrf, str) or not csrf:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state")
 
     csrf_hash = hashlib.sha256(csrf.encode("utf-8")).hexdigest()

--- a/backend/identity-service/src/services/oauth_flows.py
+++ b/backend/identity-service/src/services/oauth_flows.py
@@ -8,9 +8,20 @@ replay protection -- is enforced here via Redis (see ``_consume_state_nonce``).
 Callbacks return an ``OAuthCallbackResult`` (token + the decoded state
 fields); the frontend handles its own redirect back to ``origin``. Provider
 code-exchange does outbound HTTP from identity-svc.
+
+The state alone is NOT proof the callback came from the same browser that
+started the flow -- anyone can obtain a validly-signed state by calling
+``get_url`` themselves (login/account-linking CSRF). ``callback``/``link``
+close that gap by comparing ``sha256(csrf)`` (``csrf`` being the RAW value of
+an HttpOnly cookie set when the flow started) against the hash embedded in
+the state (see ``_verify_csrf_binding``); a missing or mismatched cookie is
+rejected exactly like an invalid state (fail closed).
 """
 
 from __future__ import annotations
+
+import hashlib
+import hmac
 
 from loguru import logger
 from redis.exceptions import RedisError
@@ -40,11 +51,13 @@ def list_providers() -> list[schemas.OAuthProviderAvailability]:
     return [schemas.OAuthProviderAvailability(provider=p) for p in OAuthService.get_available_providers()]
 
 
-def get_url(provider: str, *, origin: str, redirect: str, action: str) -> schemas.OAuthURL:
+def get_url(provider: str, *, origin: str, redirect: str, action: str, csrf: str) -> schemas.OAuthURL:
     if action not in _VALID_OAUTH_ACTIONS:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid OAuth action: {action}")
     try:
-        url, state = OAuthService.generate_oauth_url(provider, origin=origin, redirect=redirect, action=action)
+        url, state = OAuthService.generate_oauth_url(
+            provider, origin=origin, redirect=redirect, action=action, csrf=csrf
+        )
         return schemas.OAuthURL(provider=schemas.OAuthProvider(provider), url=url, state=state)
     except HTTPException:
         raise
@@ -72,6 +85,31 @@ def _verify_state_for(provider: str, state: str, *, expected_action: str) -> Sta
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state")
 
     return payload
+
+
+def _verify_csrf_binding(payload: StatePayload, csrf: str | None) -> None:
+    """Bind the verified ``state`` to the browser that started the flow.
+
+    ``payload.csrf`` is ``sha256(raw_cookie_token)``, computed at ``get_url``
+    time (see ``OAuthService.encode_state``). ``csrf`` here is the RAW value
+    of that same HttpOnly cookie, forwarded by the frontend on the
+    callback/link RPC call. A state alone can be minted by anyone (they can
+    call ``get_url`` for themselves) -- what an attacker running a login/
+    account-linking CSRF attack CANNOT do is read the victim's HttpOnly
+    cookie, so they cannot supply a ``csrf`` whose hash matches
+    ``payload.csrf``.
+
+    Fails CLOSED: a missing cookie (``csrf`` falsy) or a hash mismatch is
+    always rejected with the same "invalid state" error the rest of this
+    module uses -- never distinguished in the response, and the raw token is
+    never logged (only compared, in constant time).
+    """
+    if not csrf:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state")
+
+    csrf_hash = hashlib.sha256(csrf.encode("utf-8")).hexdigest()
+    if not hmac.compare_digest(csrf_hash, payload.csrf):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state")
 
 
 async def _consume_state_nonce(payload: StatePayload) -> None:
@@ -107,8 +145,10 @@ async def callback(
     state: str,
     user_agent: str | None,
     ip_address: str | None,
+    csrf: str | None,
 ) -> schemas.OAuthCallbackResult:
     payload = _verify_state_for(provider, state, expected_action="login")
+    _verify_csrf_binding(payload, csrf)
     await _consume_state_nonce(payload)
 
     auth_user, _ = await OAuthService.handle_callback(session, provider, code)
@@ -146,8 +186,11 @@ async def callback(
     )
 
 
-async def link(session: AsyncSession, user: models.AuthUser, provider: str, code: str, state: str) -> dict:
+async def link(
+    session: AsyncSession, user: models.AuthUser, provider: str, code: str, state: str, csrf: str | None
+) -> dict:
     payload = _verify_state_for(provider, state, expected_action="link")
+    _verify_csrf_binding(payload, csrf)
     await _consume_state_nonce(payload)
 
     provider_impl = OAuthService.get_provider(provider)

--- a/backend/identity-service/src/services/oauth_flows.py
+++ b/backend/identity-service/src/services/oauth_flows.py
@@ -1,12 +1,19 @@
 """RPC-callable OAuth flows (port of routes/oauth.py).
 
-OAuth state is stateless (HMAC-signed with TTL) so it works across RPC calls
-with no shared storage. Callbacks return a Token (the frontend handles its own
-redirect). Provider code-exchange does outbound HTTP from identity-svc.
+OAuth ``state`` is a signed, self-contained payload (HMAC + short TTL) that
+carries the originating host/redirect/action, so it works across RPC calls
+and across the ONE fixed apex callback with no shared storage for the CSRF
+check itself. The one part that DOES need shared storage -- single-use nonce
+replay protection -- is enforced here via Redis (see ``_consume_state_nonce``).
+Callbacks return an ``OAuthCallbackResult`` (token + the decoded state
+fields); the frontend handles its own redirect back to ``origin``. Provider
+code-exchange does outbound HTTP from identity-svc.
 """
 
 from __future__ import annotations
 
+from loguru import logger
+from redis.exceptions import RedisError
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,22 +23,81 @@ from shared.core.social import OAUTH_TO_SOCIAL
 from shared.models.identity.oauth import OAuthConnection
 from shared.models.identity.social import SocialAccount
 from src import models, schemas
+from src.core.config import settings
+from src.core.redis import get_redis
 from src.services.auth_service import AuthService
-from src.services.oauth_service import OAuthService
+from src.services.oauth_service import OAuthService, StatePayload
+
+# Actions a signed OAuth ``state`` may carry. "login" starts/continues a
+# session; "link" attaches a provider to the CURRENT authenticated user.
+_VALID_OAUTH_ACTIONS = frozenset({"login", "link"})
+
+# Redis key prefix for single-use OAuth state nonces (replay protection).
+_STATE_NONCE_PREFIX = "oauth:state-nonce:"
 
 
 def list_providers() -> list[schemas.OAuthProviderAvailability]:
     return [schemas.OAuthProviderAvailability(provider=p) for p in OAuthService.get_available_providers()]
 
 
-def get_url(provider: str) -> schemas.OAuthURL:
+def get_url(provider: str, *, origin: str, redirect: str, action: str) -> schemas.OAuthURL:
+    if action not in _VALID_OAUTH_ACTIONS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid OAuth action: {action}")
     try:
-        url, state = OAuthService.generate_oauth_url(provider)
+        url, state = OAuthService.generate_oauth_url(provider, origin=origin, redirect=redirect, action=action)
         return schemas.OAuthURL(provider=schemas.OAuthProvider(provider), url=url, state=state)
     except HTTPException:
         raise
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid provider: {provider}") from exc
+
+
+def _verify_state_for(provider: str, state: str, *, expected_action: str) -> StatePayload:
+    """Verify a signed ``state``, and that it was minted for THIS provider and action.
+
+    ``OAuthService.verify_state`` only checks the HMAC + expiry (it has no
+    notion of "the provider/action the caller expects"); the provider/action
+    match here is what stops a state signed for e.g. a Discord *login* being
+    replayed against a Twitch *link* callback.
+    """
+    try:
+        payload = OAuthService.verify_state(state)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired OAuth state",
+        ) from exc
+
+    if payload.provider != provider or payload.action != expected_action:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state")
+
+    return payload
+
+
+async def _consume_state_nonce(payload: StatePayload) -> None:
+    """Enforce single-use of a verified state's nonce (replay protection).
+
+    ``OAuthService.verify_state`` is pure/Redis-free on purpose (HMAC + exp
+    only, so it stays unit-testable with no infra); this is the Redis-backed
+    half that rejects a state being redeemed a second time. The nonce key's
+    TTL mirrors the state's own expiry window, so it never outlives the state
+    that carried it. If Redis is unreachable this fails OPEN (logs and lets
+    the flow continue) rather than locking out every OAuth login -- the same
+    posture ``init_redis()`` already takes for this service -- and the
+    exp-bounded state format still caps the replay window at
+    ``OAUTH_STATE_EXPIRE_MINUTES``.
+    """
+    ttl_seconds = max(settings.OAUTH_STATE_EXPIRE_MINUTES, 1) * 60
+    key = f"{_STATE_NONCE_PREFIX}{payload.provider}:{payload.nonce}"
+    try:
+        redis = get_redis()
+        consumed = await redis.set(key, "1", nx=True, ex=ttl_seconds)
+    except (RuntimeError, RedisError) as exc:
+        logger.warning(f"OAuth state nonce replay-check unavailable, continuing without it: {exc}")
+        return
+
+    if not consumed:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="OAuth state has already been used")
 
 
 async def callback(
@@ -41,8 +107,10 @@ async def callback(
     state: str,
     user_agent: str | None,
     ip_address: str | None,
-) -> schemas.Token:
-    OAuthService.validate_oauth_state(provider, state)
+) -> schemas.OAuthCallbackResult:
+    payload = _verify_state_for(provider, state, expected_action="login")
+    await _consume_state_nonce(payload)
+
     auth_user, _ = await OAuthService.handle_callback(session, provider, code)
 
     if not auth_user.is_active:
@@ -69,11 +137,19 @@ async def callback(
         user_agent=user_agent,
         ip_address=ip_address,
     )
-    return schemas.Token(access_token=access_token, refresh_token=refresh_token)
+    return schemas.OAuthCallbackResult(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        origin=payload.origin,
+        redirect=payload.redirect,
+        action=payload.action,
+    )
 
 
 async def link(session: AsyncSession, user: models.AuthUser, provider: str, code: str, state: str) -> dict:
-    OAuthService.validate_oauth_state(provider, state)
+    payload = _verify_state_for(provider, state, expected_action="link")
+    await _consume_state_nonce(payload)
+
     provider_impl = OAuthService.get_provider(provider)
     token_data = await provider_impl.exchange_code(code)
     oauth_user_info = await provider_impl.get_user_info(token_data["access_token"])
@@ -82,6 +158,9 @@ async def link(session: AsyncSession, user: models.AuthUser, provider: str, code
         "message": f"{provider.title()} account linked successfully",
         "provider": provider,
         "username": oauth_user_info.username,
+        "origin": payload.origin,
+        "redirect": payload.redirect,
+        "action": payload.action,
     }
 
 

--- a/backend/identity-service/src/services/oauth_service.py
+++ b/backend/identity-service/src/services/oauth_service.py
@@ -4,8 +4,10 @@ Generic OAuth service for multiple providers
 
 import base64
 import hmac
+import json
 import secrets
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlencode
@@ -379,6 +381,27 @@ class BattleNetOAuthProvider(OAuthProviderBase):
             ) from e
 
 
+@dataclass(frozen=True)
+class StatePayload:
+    """Decoded, verified contents of a signed OAuth ``state`` parameter.
+
+    Carries the originating host (``origin``), the post-auth redirect path
+    (``redirect``), and the intent (``action``: ``"login"`` or ``"link"``) so
+    the callback -- which always lands on the ONE fixed apex callback URL
+    registered with each provider -- can send the user back to the tenant
+    subdomain that started the flow. ``nonce`` is exposed so the caller can
+    enforce single-use / replay protection (see ``oauth_flows.callback``);
+    ``verify_state`` itself does not consume it.
+    """
+
+    origin: str
+    redirect: str
+    action: str
+    provider: str
+    nonce: str
+    exp: int
+
+
 class OAuthService:
     """Generic OAuth service handling multiple providers"""
 
@@ -409,8 +432,6 @@ class OAuthService:
             "redirect_uri": "OAUTH_REDIRECT",
         },
     }
-
-    _state_prefix = "v1"
 
     @classmethod
     def _provider_config(cls, provider_name: str) -> dict[str, str]:
@@ -462,42 +483,79 @@ class OAuthService:
         return base64.urlsafe_b64decode(padded.encode("utf-8"))
 
     @classmethod
-    def _build_state_signature(cls, provider_name: str, issued_at: int, nonce: str) -> str:
-        payload = f"oauth-state:{provider_name}:{issued_at}:{nonce}"
-        digest = bytes.fromhex(key_derivation.hmac_sha256_hex(_OAUTH_STATE_KEY, payload))
+    def _build_payload_signature(cls, payload_json: bytes) -> str:
+        digest = bytes.fromhex(key_derivation.hmac_sha256_hex(_OAUTH_STATE_KEY, payload_json.decode("utf-8")))
         return cls._encode_state_part(digest)
 
     @classmethod
-    def generate_oauth_state(cls, provider_name: str) -> str:
-        nonce = cls._encode_state_part(secrets.token_bytes(24))
-        issued_at = int(datetime.now(UTC).timestamp())
-        signature = cls._build_state_signature(provider_name, issued_at, nonce)
-        return f"{cls._state_prefix}.{issued_at}.{nonce}.{signature}"
+    def encode_state(cls, *, origin: str, redirect: str, action: str, provider: str) -> str:
+        """Build a signed, short-lived OAuth ``state`` carrying the originating
+        host, post-auth redirect path, and action (``login``/``link``)
+        alongside the provider.
+
+        Pure and Redis/DB-free: the returned string is fully self-contained
+        (``base64url(json) + "." + base64url(hmac)``), so it round-trips
+        through any provider's redirect with no shared storage, and
+        ``verify_state`` can check it with nothing but the signing key. Nonce
+        single-use / replay protection is enforced separately by the caller
+        that has access to Redis (see ``oauth_flows.callback``) -- keeping
+        this function unit-testable without any infra.
+        """
+        now_ts = int(datetime.now(UTC).timestamp())
+        ttl_seconds = max(settings.OAUTH_STATE_EXPIRE_MINUTES, 1) * 60
+        payload = {
+            "o": origin,
+            "r": redirect,
+            "a": action,
+            "p": provider,
+            "n": cls._encode_state_part(secrets.token_bytes(24)),
+            "e": now_ts + ttl_seconds,
+        }
+        payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        signature = cls._build_payload_signature(payload_json)
+        return f"{cls._encode_state_part(payload_json)}.{signature}"
 
     @classmethod
-    def validate_oauth_state(cls, provider_name: str, state: str) -> None:
-        try:
-            version, issued_at_raw, nonce, signature = state.split(".", maxsplit=3)
-            if version != cls._state_prefix:
-                raise ValueError("invalid state version")
+    def verify_state(cls, state: str) -> StatePayload:
+        """Verify a signed OAuth ``state`` and decode its payload.
 
-            issued_at = int(issued_at_raw)
+        Pure and Redis/DB-free: checks the HMAC signature (constant-time
+        comparison) and the embedded expiry only. Raises ``ValueError`` if
+        the state is missing, malformed, tampered with, or expired -- never
+        ``HTTPException``, so this stays usable from a plain unit test.
+        Nonce single-use / replay protection is intentionally NOT enforced
+        here; the caller must consume ``StatePayload.nonce`` itself (see
+        ``oauth_flows.callback``).
+        """
+        if not state or not isinstance(state, str):
+            raise ValueError("state is required")
+
+        try:
+            encoded_payload, signature = state.split(".", maxsplit=1)
+            payload_json = cls._decode_state_part(encoded_payload)
+
+            expected_signature = cls._build_payload_signature(payload_json)
+            if not hmac.compare_digest(signature, expected_signature):
+                raise ValueError("invalid state signature")
+
+            payload = json.loads(payload_json)
+            exp = int(payload["e"])
             now_ts = int(datetime.now(UTC).timestamp())
-            state_ttl_seconds = max(settings.OAUTH_STATE_EXPIRE_MINUTES, 1) * 60
-            if issued_at > now_ts + 60 or now_ts - issued_at > state_ttl_seconds:
+            if now_ts > exp:
                 raise ValueError("state expired")
 
-            expected_sig = cls._build_state_signature(provider_name, issued_at, nonce)
-            if not hmac.compare_digest(signature, expected_sig):
-                raise ValueError("invalid signature")
-
-            # Validate nonce is valid base64url
-            cls._decode_state_part(nonce)
+            return StatePayload(
+                origin=str(payload["o"]),
+                redirect=str(payload["r"]),
+                action=str(payload["a"]),
+                provider=str(payload["p"]),
+                nonce=str(payload["n"]),
+                exp=exp,
+            )
+        except ValueError:
+            raise
         except Exception as exc:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Invalid or expired OAuth state",
-            ) from exc
+            raise ValueError("malformed OAuth state") from exc
 
     @classmethod
     def get_provider(cls, provider_name: str) -> OAuthProviderBase:
@@ -511,13 +569,18 @@ class OAuthService:
         return provider
 
     @classmethod
-    def generate_oauth_url(cls, provider_name: str, state: str | None = None) -> tuple[str, str]:
+    def generate_oauth_url(cls, provider_name: str, *, origin: str, redirect: str, action: str) -> tuple[str, str]:
         """
-        Generate OAuth URL for specified provider
-        Returns (url, state)
+        Generate an OAuth authorization URL for the given provider.
+
+        ``redirect_uri`` stays ``settings.OAUTH_REDIRECT`` -- the ONE fixed
+        apex callback registered with every provider -- regardless of
+        ``origin``. ``origin``/``redirect``/``action`` travel inside the
+        signed ``state`` instead, so the callback (which always lands on that
+        one fixed URL) can send the user back to the tenant subdomain that
+        started the flow. Returns (url, state).
         """
-        if not state:
-            state = cls.generate_oauth_state(provider_name)
+        state = cls.encode_state(origin=origin, redirect=redirect, action=action, provider=provider_name)
 
         provider = cls.get_provider(provider_name)
         url = provider.get_authorization_url(state)

--- a/backend/identity-service/src/services/oauth_service.py
+++ b/backend/identity-service/src/services/oauth_service.py
@@ -3,6 +3,7 @@ Generic OAuth service for multiple providers
 """
 
 import base64
+import hashlib
 import hmac
 import json
 import secrets
@@ -391,7 +392,12 @@ class StatePayload:
     registered with each provider -- can send the user back to the tenant
     subdomain that started the flow. ``nonce`` is exposed so the caller can
     enforce single-use / replay protection (see ``oauth_flows.callback``);
-    ``verify_state`` itself does not consume it.
+    ``verify_state`` itself does not consume it. ``csrf`` is the SHA-256 hex
+    digest of the raw CSRF cookie value that was live in the browser when the
+    flow started (browser-binding, closes OAuth login/link CSRF) -- this
+    dataclass never carries the raw token, only its hash, and does not
+    compare it against anything; the caller (``oauth_flows``) does that with
+    the raw cookie value it receives separately.
     """
 
     origin: str
@@ -400,6 +406,7 @@ class StatePayload:
     provider: str
     nonce: str
     exp: int
+    csrf: str
 
 
 class OAuthService:
@@ -488,10 +495,20 @@ class OAuthService:
         return cls._encode_state_part(digest)
 
     @classmethod
-    def encode_state(cls, *, origin: str, redirect: str, action: str, provider: str) -> str:
+    def encode_state(cls, *, origin: str, redirect: str, action: str, provider: str, csrf: str) -> str:
         """Build a signed, short-lived OAuth ``state`` carrying the originating
         host, post-auth redirect path, and action (``login``/``link``)
         alongside the provider.
+
+        ``csrf`` is the RAW CSRF cookie token (never the hash) that was live
+        in the browser that is about to start this flow; only its SHA-256 hex
+        digest is stored in the payload (short key ``"c"``) -- the raw value
+        itself is never persisted, signed into anything retrievable, or
+        logged. This is what lets ``oauth_flows`` bind the eventual callback
+        to the SAME browser: an attacker can trigger ``get_url`` for
+        themselves and obtain a validly-signed ``state``, but cannot read the
+        victim's HttpOnly cookie, so they cannot produce a ``csrf`` value
+        whose hash matches this one.
 
         Pure and Redis/DB-free: the returned string is fully self-contained
         (``base64url(json) + "." + base64url(hmac)``), so it round-trips
@@ -503,6 +520,7 @@ class OAuthService:
         """
         now_ts = int(datetime.now(UTC).timestamp())
         ttl_seconds = max(settings.OAUTH_STATE_EXPIRE_MINUTES, 1) * 60
+        csrf_hash = hashlib.sha256(csrf.encode("utf-8")).hexdigest()
         payload = {
             "o": origin,
             "r": redirect,
@@ -510,6 +528,7 @@ class OAuthService:
             "p": provider,
             "n": cls._encode_state_part(secrets.token_bytes(24)),
             "e": now_ts + ttl_seconds,
+            "c": csrf_hash,
         }
         payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
         signature = cls._build_payload_signature(payload_json)
@@ -525,7 +544,10 @@ class OAuthService:
         ``HTTPException``, so this stays usable from a plain unit test.
         Nonce single-use / replay protection is intentionally NOT enforced
         here; the caller must consume ``StatePayload.nonce`` itself (see
-        ``oauth_flows.callback``).
+        ``oauth_flows.callback``). Likewise, this function only returns the
+        stored ``csrf`` hash (``StatePayload.csrf``) -- it does NOT compare it
+        against a cookie, since that requires the raw cookie value which only
+        the RPC-layer caller (``oauth_flows``) has access to.
         """
         if not state or not isinstance(state, str):
             raise ValueError("state is required")
@@ -551,6 +573,7 @@ class OAuthService:
                 provider=str(payload["p"]),
                 nonce=str(payload["n"]),
                 exp=exp,
+                csrf=str(payload["c"]),
             )
         except ValueError:
             raise
@@ -569,7 +592,9 @@ class OAuthService:
         return provider
 
     @classmethod
-    def generate_oauth_url(cls, provider_name: str, *, origin: str, redirect: str, action: str) -> tuple[str, str]:
+    def generate_oauth_url(
+        cls, provider_name: str, *, origin: str, redirect: str, action: str, csrf: str
+    ) -> tuple[str, str]:
         """
         Generate an OAuth authorization URL for the given provider.
 
@@ -578,9 +603,12 @@ class OAuthService:
         ``origin``. ``origin``/``redirect``/``action`` travel inside the
         signed ``state`` instead, so the callback (which always lands on that
         one fixed URL) can send the user back to the tenant subdomain that
-        started the flow. Returns (url, state).
+        started the flow. ``csrf`` is the RAW CSRF cookie token (never
+        stored, never logged) -- only its SHA-256 hash is embedded in the
+        signed state (see ``encode_state``), binding the eventual callback to
+        the same browser. Returns (url, state).
         """
-        state = cls.encode_state(origin=origin, redirect=redirect, action=action, provider=provider_name)
+        state = cls.encode_state(origin=origin, redirect=redirect, action=action, provider=provider_name, csrf=csrf)
 
         provider = cls.get_provider(provider_name)
         url = provider.get_authorization_url(state)

--- a/backend/identity-service/tests/test_oauth_state.py
+++ b/backend/identity-service/tests/test_oauth_state.py
@@ -287,3 +287,34 @@ def test_link_rejects_mismatched_csrf() -> None:
         )
 
     assert exc_info.value.status_code == 400
+
+
+def test_link_rejects_missing_csrf() -> None:
+    """Fail closed: no cookie forwarded on the ``link`` flow -- the same
+    browser-binding requirement as ``callback``.
+
+    Both ``_verify_state_for`` and ``_verify_csrf_binding`` run before
+    ``link`` ever touches the DB, so this is testable with ``session``
+    left as ``None`` and no infra running.
+    """
+    state = OAuthService.encode_state(
+        origin="https://owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="link",
+        provider="battlenet",
+        csrf="the-real-browser-cookie-value",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            oauth_flows.link(
+                session=None,
+                user=None,
+                provider="battlenet",
+                code="unused-code",
+                state=state,
+                csrf=None,
+            )
+        )
+
+    assert exc_info.value.status_code == 400

--- a/backend/identity-service/tests/test_oauth_state.py
+++ b/backend/identity-service/tests/test_oauth_state.py
@@ -1,11 +1,21 @@
-"""Signed OAuth ``state`` payload: encode/verify round-trip (Task 9).
+"""Signed OAuth ``state`` payload: encode/verify round-trip (Task 9) plus the
+browser-binding CSRF hash (Task 9b).
 
 Pure and Redis/DB-free by design — ``encode_state``/``verify_state`` only do
 HMAC signing + an embedded expiry check. Nonce single-use (replay) protection
 is enforced separately in ``oauth_flows.callback`` where a Redis client is
 available; that half is intentionally NOT exercised here (see brief).
+
+Task 9b adds a ``csrf`` field: the state carries only ``sha256(raw_token)``,
+never the raw token itself. The flow-level compare against the raw cookie
+value (``oauth_flows._verify_csrf_binding``, exercised via ``callback``/
+``link``) IS unit-testable without infra, because a missing/mismatched
+cookie is rejected before either function ever touches Redis or the DB --
+see ``test_callback_rejects_missing_csrf`` / ``test_link_rejects_mismatched_csrf``.
 """
 
+import asyncio
+import hashlib
 import json
 import os
 import sys
@@ -51,6 +61,7 @@ def test_state_roundtrip_carries_origin_and_action() -> None:
         redirect="/account",
         action="login",
         provider="discord",
+        csrf="raw-csrf-token",
     )
 
     payload = OAuthService.verify_state(state)
@@ -69,6 +80,7 @@ def test_state_roundtrip_carries_link_action() -> None:
         redirect="/account",
         action="link",
         provider="battlenet",
+        csrf="raw-csrf-token",
     )
 
     payload = OAuthService.verify_state(state)
@@ -77,8 +89,30 @@ def test_state_roundtrip_carries_link_action() -> None:
     assert payload.provider == "battlenet"
 
 
+def test_state_roundtrip_carries_csrf_hash() -> None:
+    """The state stores sha256(raw token), never the raw token itself."""
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="login",
+        provider="discord",
+        csrf="super-secret-cookie-value",
+    )
+
+    payload = OAuthService.verify_state(state)
+
+    assert payload.csrf == hashlib.sha256(b"super-secret-cookie-value").hexdigest()
+    assert "super-secret-cookie-value" not in state
+
+
 def test_state_nonces_are_unique() -> None:
-    kwargs = {"origin": "https://team-a.owt.craazzzyyfoxx.me", "redirect": "/", "action": "login", "provider": "discord"}
+    kwargs = {
+        "origin": "https://team-a.owt.craazzzyyfoxx.me",
+        "redirect": "/",
+        "action": "login",
+        "provider": "discord",
+        "csrf": "raw-csrf-token",
+    }
 
     first = OAuthService.verify_state(OAuthService.encode_state(**kwargs))
     second = OAuthService.verify_state(OAuthService.encode_state(**kwargs))
@@ -92,6 +126,7 @@ def test_state_rejects_tamper() -> None:
         redirect="/",
         action="login",
         provider="discord",
+        csrf="raw-csrf-token",
     )
     tampered = state[:-2] + ("aa" if not state.endswith("aa") else "bb")
 
@@ -113,6 +148,7 @@ def test_state_rejects_expired() -> None:
         redirect="/",
         action="login",
         provider="discord",
+        csrf="raw-csrf-token",
     )
     encoded_payload, _signature = state.split(".", maxsplit=1)
     payload = json.loads(OAuthService._decode_state_part(encoded_payload))
@@ -135,6 +171,7 @@ def test_get_url_embeds_origin_redirect_action(monkeypatch: pytest.MonkeyPatch) 
         origin="https://team-a.owt.craazzzyyfoxx.me",
         redirect="/account",
         action="login",
+        csrf="raw-csrf-token",
     )
 
     payload = OAuthService.verify_state(result.state)
@@ -144,6 +181,9 @@ def test_get_url_embeds_origin_redirect_action(monkeypatch: pytest.MonkeyPatch) 
     assert payload.provider == "discord"
     # redirect_uri must stay the fixed apex callback -- never derived from origin.
     assert "team-a" not in result.url
+    # the raw cookie token never appears in the state or the URL -- only its hash.
+    assert "raw-csrf-token" not in result.state
+    assert "raw-csrf-token" not in result.url
 
 
 def test_get_url_rejects_invalid_action(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -156,6 +196,94 @@ def test_get_url_rejects_invalid_action(monkeypatch: pytest.MonkeyPatch) -> None
             origin="https://team-a.owt.craazzzyyfoxx.me",
             redirect="/",
             action="delete-everything",
+            csrf="raw-csrf-token",
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_callback_rejects_missing_csrf() -> None:
+    """Fail closed: no cookie forwarded at all -- the whole point of the binding.
+
+    Both ``_verify_state_for`` and ``_verify_csrf_binding`` run before
+    ``callback`` ever touches Redis (``_consume_state_nonce``) or the DB
+    (``OAuthService.handle_callback``), so this is testable with ``session``
+    left as ``None`` and no infra running.
+    """
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/",
+        action="login",
+        provider="discord",
+        csrf="the-real-browser-cookie-value",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            oauth_flows.callback(
+                session=None,
+                provider="discord",
+                code="unused-code",
+                state=state,
+                user_agent=None,
+                ip_address=None,
+                csrf=None,
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_callback_rejects_mismatched_csrf() -> None:
+    """A state minted while the victim's browser held one cookie value must
+    reject a callback presenting any other value -- e.g. an attacker's own
+    cookie, forwarded while replaying a state they tricked the victim into
+    using (login CSRF)."""
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/",
+        action="login",
+        provider="discord",
+        csrf="the-real-browser-cookie-value",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            oauth_flows.callback(
+                session=None,
+                provider="discord",
+                code="unused-code",
+                state=state,
+                user_agent=None,
+                ip_address=None,
+                csrf="an-attackers-forged-cookie-value",
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+def test_link_rejects_mismatched_csrf() -> None:
+    """Account-linking CSRF: the same browser-binding must be enforced on
+    the ``link`` flow, not just ``callback``."""
+    state = OAuthService.encode_state(
+        origin="https://owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="link",
+        provider="battlenet",
+        csrf="the-real-browser-cookie-value",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            oauth_flows.link(
+                session=None,
+                user=None,
+                provider="battlenet",
+                code="unused-code",
+                state=state,
+                csrf="an-attackers-forged-cookie-value",
+            )
         )
 
     assert exc_info.value.status_code == 400

--- a/backend/identity-service/tests/test_oauth_state.py
+++ b/backend/identity-service/tests/test_oauth_state.py
@@ -1,0 +1,161 @@
+"""Signed OAuth ``state`` payload: encode/verify round-trip (Task 9).
+
+Pure and Redis/DB-free by design — ``encode_state``/``verify_state`` only do
+HMAC signing + an embedded expiry check. Nonce single-use (replay) protection
+is enforced separately in ``oauth_flows.callback`` where a Redis client is
+available; that half is intentionally NOT exercised here (see brief).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from shared.core.errors import BaseAPIException as HTTPException
+
+
+def _ensure_test_env() -> None:
+    env = {
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DB": "auth_test",
+        "POSTGRES_USER": "postgres",
+        "POSTGRES_PASSWORD": "postgres",
+        "JWT_SECRET_KEY": "test-secret",
+        "DISCORD_CLIENT_ID": "discord-client",
+        "DISCORD_CLIENT_SECRET": "discord-secret",
+        "TWITCH_CLIENT_ID": "twitch-client",
+        "TWITCH_CLIENT_SECRET": "twitch-secret",
+        "BATTLENET_CLIENT_ID": "battlenet-client",
+        "BATTLENET_CLIENT_SECRET": "battlenet-secret",
+        "OAUTH_REDIRECT": "http://localhost:3000/auth/callback",
+    }
+    for key, value in env.items():
+        os.environ.setdefault(key, value)
+
+
+_ensure_test_env()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.services import oauth_flows  # noqa: E402
+from src.services.oauth_service import OAuthService  # noqa: E402
+
+
+def test_state_roundtrip_carries_origin_and_action() -> None:
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="login",
+        provider="discord",
+    )
+
+    payload = OAuthService.verify_state(state)
+
+    assert payload.origin == "https://team-a.owt.craazzzyyfoxx.me"
+    assert payload.redirect == "/account"
+    assert payload.action == "login"
+    assert payload.provider == "discord"
+    assert payload.nonce
+    assert payload.exp > 0
+
+
+def test_state_roundtrip_carries_link_action() -> None:
+    state = OAuthService.encode_state(
+        origin="https://owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="link",
+        provider="battlenet",
+    )
+
+    payload = OAuthService.verify_state(state)
+
+    assert payload.action == "link"
+    assert payload.provider == "battlenet"
+
+
+def test_state_nonces_are_unique() -> None:
+    kwargs = {"origin": "https://team-a.owt.craazzzyyfoxx.me", "redirect": "/", "action": "login", "provider": "discord"}
+
+    first = OAuthService.verify_state(OAuthService.encode_state(**kwargs))
+    second = OAuthService.verify_state(OAuthService.encode_state(**kwargs))
+
+    assert first.nonce != second.nonce
+
+
+def test_state_rejects_tamper() -> None:
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/",
+        action="login",
+        provider="discord",
+    )
+    tampered = state[:-2] + ("aa" if not state.endswith("aa") else "bb")
+
+    with pytest.raises(ValueError):
+        OAuthService.verify_state(tampered)
+
+
+def test_state_rejects_malformed() -> None:
+    with pytest.raises(ValueError):
+        OAuthService.verify_state("not-a-valid-state")
+
+    with pytest.raises(ValueError):
+        OAuthService.verify_state("")
+
+
+def test_state_rejects_expired() -> None:
+    state = OAuthService.encode_state(
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/",
+        action="login",
+        provider="discord",
+    )
+    encoded_payload, _signature = state.split(".", maxsplit=1)
+    payload = json.loads(OAuthService._decode_state_part(encoded_payload))
+    payload["e"] = 0  # epoch 0 -- long expired
+
+    expired_payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    expired_signature = OAuthService._build_payload_signature(expired_payload_json)
+    expired_state = f"{OAuthService._encode_state_part(expired_payload_json)}.{expired_signature}"
+
+    with pytest.raises(ValueError):
+        OAuthService.verify_state(expired_state)
+
+
+def test_get_url_embeds_origin_redirect_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.services.oauth_service.settings.DISCORD_OAUTH_ENABLED", True)
+    monkeypatch.setattr("src.services.oauth_service.settings.OAUTH_REDIRECT", "http://localhost:3000/auth/callback")
+
+    result = oauth_flows.get_url(
+        "discord",
+        origin="https://team-a.owt.craazzzyyfoxx.me",
+        redirect="/account",
+        action="login",
+    )
+
+    payload = OAuthService.verify_state(result.state)
+    assert payload.origin == "https://team-a.owt.craazzzyyfoxx.me"
+    assert payload.redirect == "/account"
+    assert payload.action == "login"
+    assert payload.provider == "discord"
+    # redirect_uri must stay the fixed apex callback -- never derived from origin.
+    assert "team-a" not in result.url
+
+
+def test_get_url_rejects_invalid_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.services.oauth_service.settings.DISCORD_OAUTH_ENABLED", True)
+    monkeypatch.setattr("src.services.oauth_service.settings.OAUTH_REDIRECT", "http://localhost:3000/auth/callback")
+
+    with pytest.raises(HTTPException) as exc_info:
+        oauth_flows.get_url(
+            "discord",
+            origin="https://team-a.owt.craazzzyyfoxx.me",
+            redirect="/",
+            action="delete-everything",
+        )
+
+    assert exc_info.value.status_code == 400

--- a/backend/migrations/versions/wsbrand0001_add_workspace_branding.py
+++ b/backend/migrations/versions/wsbrand0001_add_workspace_branding.py
@@ -1,0 +1,43 @@
+"""add per-workspace site branding columns
+
+Adds the organiser-controlled brand palette to ``workspace``: a master toggle
+plus four hex colours (primary/secondary accent + background/surface). The rest
+of the palette is derived on the frontend; these columns are additive and
+nullable so the migration is safe on a populated table.
+
+Revision ID: wsbrand0001
+Revises: wsmbr01
+Create Date: 2026-07-06
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "wsbrand0001"
+down_revision: str | None = "wsmbr01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace",
+        sa.Column("branding_enabled", sa.Boolean(), server_default="false", nullable=False),
+    )
+    op.add_column("workspace", sa.Column("brand_primary", sa.String(), nullable=True))
+    op.add_column("workspace", sa.Column("brand_secondary", sa.String(), nullable=True))
+    op.add_column("workspace", sa.Column("brand_background", sa.String(), nullable=True))
+    op.add_column("workspace", sa.Column("brand_surface", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workspace", "brand_surface")
+    op.drop_column("workspace", "brand_background")
+    op.drop_column("workspace", "brand_secondary")
+    op.drop_column("workspace", "brand_primary")
+    op.drop_column("workspace", "branding_enabled")

--- a/backend/migrations/versions/wsdomain0001_add_workspace_subdomain_seo.py
+++ b/backend/migrations/versions/wsdomain0001_add_workspace_subdomain_seo.py
@@ -1,0 +1,32 @@
+"""add workspace subdomain + seo columns
+
+Revision ID: wsdomain0001
+Revises: wsbrand0001
+Create Date: 2026-07-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "wsdomain0001"
+down_revision: str | None = "wsbrand0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("workspace", sa.Column("subdomain", sa.String(length=63), nullable=True))
+    op.add_column("workspace", sa.Column("seo_title", sa.String(), nullable=True))
+    op.add_column("workspace", sa.Column("seo_description", sa.String(), nullable=True))
+    op.create_index("ix_workspace_subdomain", "workspace", ["subdomain"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workspace_subdomain", table_name="workspace")
+    op.drop_column("workspace", "seo_description")
+    op.drop_column("workspace", "seo_title")
+    op.drop_column("workspace", "subdomain")

--- a/backend/shared/models/tenancy/workspace.py
+++ b/backend/shared/models/tenancy/workspace.py
@@ -32,6 +32,11 @@ class Workspace(db.TimeStampIntegerMixin):
     brand_secondary: Mapped[str | None] = mapped_column(String(), nullable=True)
     brand_background: Mapped[str | None] = mapped_column(String(), nullable=True)
     brand_surface: Mapped[str | None] = mapped_column(String(), nullable=True)
+    # White-label multi-domain (Phase 1: subdomains). See
+    # docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md.
+    subdomain: Mapped[str | None] = mapped_column(String(63), unique=True, index=True, nullable=True)
+    seo_title: Mapped[str | None] = mapped_column(String(), nullable=True)
+    seo_description: Mapped[str | None] = mapped_column(String(), nullable=True)
     default_division_grid_version_id: Mapped[int | None] = mapped_column(
         ForeignKey("division_grid_version.id", ondelete="SET NULL"),
         nullable=True,

--- a/backend/shared/models/tenancy/workspace.py
+++ b/backend/shared/models/tenancy/workspace.py
@@ -23,6 +23,15 @@ class Workspace(db.TimeStampIntegerMixin):
     description: Mapped[str | None] = mapped_column(String(), nullable=True)
     icon_url: Mapped[str | None] = mapped_column(String(), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean(), server_default="true")
+    # Per-workspace site branding (main public site only). Typed hex colours
+    # (#RRGGBB); the rest of the palette (text/borders/hover) is derived on the
+    # frontend with contrast guards. ``branding_enabled`` is the master toggle so
+    # a workspace can turn branding off without losing its saved colours.
+    branding_enabled: Mapped[bool] = mapped_column(Boolean(), server_default="false")
+    brand_primary: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_secondary: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_background: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_surface: Mapped[str | None] = mapped_column(String(), nullable=True)
     default_division_grid_version_id: Mapped[int | None] = mapped_column(
         ForeignKey("division_grid_version.id", ondelete="SET NULL"),
         nullable=True,

--- a/backend/shared/repository/workspace.py
+++ b/backend/shared/repository/workspace.py
@@ -19,6 +19,16 @@ class WorkspaceRepository(BaseRepository[models.Workspace]):
     async def get_by_slug(self, session: AsyncSession, slug: str) -> models.Workspace | None:
         return await self.get_by(session, options=self.default_grid_options(), slug=slug)
 
+    async def get_by_subdomain(self, session: AsyncSession, subdomain: str) -> models.Workspace | None:
+        """Resolve a platform-zone subdomain label to its workspace (Phase 1).
+
+        Deliberately a bare lookup (no eager-loaded grid options): the
+        ``by_host`` RPC only needs ``id``/``slug`` for tenant resolution, and
+        this runs on the request-resolution hot path.
+        """
+        result = await session.execute(sa.select(models.Workspace).where(models.Workspace.subdomain == subdomain))
+        return result.scalar_one_or_none()
+
     async def get_with_default_grid(self, session: AsyncSession, workspace_id: int) -> models.Workspace | None:
         return await self.get(session, workspace_id, options=self.default_grid_options())
 

--- a/backend/shared/tenancy/hostnames.py
+++ b/backend/shared/tenancy/hostnames.py
@@ -1,0 +1,50 @@
+"""Platform-zone hostname helpers for host->workspace resolution.
+
+Phase 1 handles subdomains under the platform zone. Custom domains (Phase 2)
+match a separate column and are resolved elsewhere.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = (
+    "PLATFORM_ZONE",
+    "RESERVED_SUBDOMAINS",
+    "validate_subdomain_label",
+    "subdomain_from_host",
+)
+
+PLATFORM_ZONE = "owt.craazzzyyfoxx.me"
+
+RESERVED_SUBDOMAINS = frozenset({"www", "api", "auth", "admin", "app", "assets", "static", "cdn", "mail", "ws"})
+
+_LABEL_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def validate_subdomain_label(label: str) -> str:
+    normalized = label.strip().lower()
+    if not (1 <= len(normalized) <= 63):
+        raise ValueError("Subdomain must be 1-63 characters")
+    if not _LABEL_RE.fullmatch(normalized):
+        raise ValueError("Subdomain may contain only a-z, 0-9 and hyphen")
+    if normalized.startswith("-") or normalized.endswith("-"):
+        raise ValueError("Subdomain may not start or end with a hyphen")
+    if normalized in RESERVED_SUBDOMAINS:
+        raise ValueError(f"Subdomain '{normalized}' is reserved")
+    return normalized
+
+
+def subdomain_from_host(host: str) -> str | None:
+    if not host:
+        return None
+    hostname = host.strip().lower().split(":", 1)[0]  # drop port
+    suffix = "." + PLATFORM_ZONE
+    if not hostname.endswith(suffix):
+        return None
+    label = hostname[: -len(suffix)]
+    if not label or "." in label:  # apex has empty label; multi-segment rejected
+        return None
+    if label == "www" or label in RESERVED_SUBDOMAINS:
+        return None
+    return label

--- a/backend/shared/tenancy/hostnames.py
+++ b/backend/shared/tenancy/hostnames.py
@@ -45,6 +45,7 @@ def subdomain_from_host(host: str) -> str | None:
     label = hostname[: -len(suffix)]
     if not label or "." in label:  # apex has empty label; multi-segment rejected
         return None
-    if label == "www" or label in RESERVED_SUBDOMAINS:
+    try:
+        return validate_subdomain_label(label)
+    except ValueError:
         return None
-    return label

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -460,13 +460,13 @@ services:
       dockerfile: prod.Dockerfile
       args:
         NEXT_PUBLIC_CACHE_POLICY: ${NEXT_PUBLIC_CACHE_POLICY}
-        NEXT_PUBLIC_SITE_NAME: ${NEXT_PUBLIC_SITE_NAME}
-        NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL}
+        NEXT_PUBLIC_SITE_NAME: Overwatch Tournaments
+        NEXT_PUBLIC_SITE_URL: https://owt.craazzzyyfoxx.me
         NEXT_PUBLIC_SITE_ICON: ${NEXT_PUBLIC_SITE_ICON}
         NEXT_PUBLIC_SITE_FAVICON: ${NEXT_PUBLIC_SITE_FAVICON}
     environment:
-      - NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL}
-      - NEXT_PUBLIC_SITE_NAME=${NEXT_PUBLIC_SITE_NAME}
+      - NEXT_PUBLIC_SITE_URL=https://owt.craazzzyyfoxx.me
+      - NEXT_PUBLIC_SITE_NAME=Overwatch Tournaments
       - NEXT_PUBLIC_CACHE_POLICY=${NEXT_PUBLIC_CACHE_POLICY}
       # Single gateway origin: the browser uses relative same-origin paths; only
       # server-side (SSR + route handlers + middleware) fetches need a base.

--- a/docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md
+++ b/docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md
@@ -47,7 +47,7 @@ The TLS termination is handled by Traefik (external to the docker-compose stack,
 
 ### Wildcard Certificate via DNS-01 ACME
 
-**Rationale:** A wildcard certificate for `*.owt.craazzzyyfoxx.me` covers both the apex and all subdomains, avoiding Let's Encrypt's per-domain rate limits and simplifying multi-tenant DNS validation.
+**Rationale:** A wildcard certificate for `*.owt.craazzzyyfoxx.me` covers all subdomains. To also cover the bare apex domain `owt.craazzzyyfoxx.me`, both the apex and the wildcard must be included as SANs (Subject Alternative Names) on the same certificate. This avoids Let's Encrypt's per-domain rate limits and simplifies multi-tenant DNS validation.
 
 #### Prerequisites
 
@@ -91,13 +91,22 @@ certificatesResolvers:
 
 #### Certificate Issuance
 
-Traefik will automatically request and renew the certificate when a matching route (host rule) is first accessed:
+Traefik will automatically request and renew the certificate when a matching route (host rule) is first accessed. The `tls.domains` configuration explicitly specifies that both the apex and wildcard must be on the same certificate:
 
 ```yaml
 # In Traefik router/service config
 - Host(`owt.craazzzyyfoxx.me`) || HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.owt.craazzzyyfoxx.me`)
-- CertResolver: dns-acme
+  tls:
+    certResolver: dns-acme
+    domains:
+      - main: "owt.craazzzyyfoxx.me"
+        sans:
+          - "*.owt.craazzzyyfoxx.me"
 ```
+
+**Important:** The `tls.domains` entry ensures that both the apex (`main`) and the wildcard (`sans`) are included on the certificate. Without explicit SAN configuration, Let's Encrypt may issue separate certificates.
+
+**Note on HostRegexp (Traefik version):** Traefik v2 supports named captures in `HostRegexp` (e.g., `{subdomain:[a-zA-Z0-9-]+}`). Traefik v3 removed named-capture support from `HostRegexp` — use a plain regex pattern instead if upgrading to v3.
 
 **Traefik will:**
 1. Create a DNS TXT record in your domain via API (DNS-01 challenge)
@@ -119,11 +128,38 @@ Traefik automatically renews certificates 30 days before expiry. Monitor Traefik
 
 #### Manual Renewal (if needed)
 
-```bash
-# On the host running Traefik
-traefik --acme.onHostRule=true --entryPoints.web.address=:80 \
-  --certificatesResolvers.dns-acme.acme.dnsChallenge.provider=cloudflare
-```
+In Traefik v2/v3, certificates are managed automatically by the `certificatesResolvers.<name>.acme` configuration and renew 30 days before expiry. If you need to force an immediate renewal:
+
+1. **Locate the ACME storage file** (typically `/root/overwatch-tournaments/acme.json`):
+   ```bash
+   # On the host running Traefik
+   ls -lh /root/overwatch-tournaments/acme.json
+   ```
+
+2. **Remove the stored certificate entry** (this forces re-issuance on next route access):
+   ```bash
+   # Backup first
+   cp /root/overwatch-tournaments/acme.json /root/overwatch-tournaments/acme.json.backup
+   
+   # Remove the certificate entry (or delete the entire file to force re-issuance)
+   rm /root/overwatch-tournaments/acme.json
+   ```
+
+3. **Restart Traefik** to trigger certificate re-issuance:
+   ```bash
+   # If Traefik runs as systemd service
+   sudo systemctl restart traefik
+   
+   # Or if running in Docker
+   docker restart traefik
+   ```
+
+4. **Monitor logs** to confirm the new certificate is issued:
+   ```bash
+   docker logs traefik | grep -i acme
+   # or
+   journalctl -u traefik -f
+   ```
 
 ---
 

--- a/docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md
+++ b/docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md
@@ -1,0 +1,290 @@
+# Workspace Subdomains: Ops Runbook
+
+**Date:** 2026-07-06  
+**Platform Zone:** `owt.craazzzyyfoxx.me`  
+**Phase:** 1 (subdomains, single OAuth callback)
+
+This document describes the out-of-repo operational steps required to enable workspace multi-domain support via subdomains.
+
+---
+
+## 1. DNS Records
+
+### Wildcard A Record
+Create a wildcard DNS record that resolves all tenant subdomains to the ingress IP:
+
+```
+*.owt.craazzzyyfoxx.me  A  <INGRESS_IP>
+```
+
+**Where to configure:** Your DNS provider (CloudFlare, Route53, etc.)  
+**TTL:** 300 seconds (or provider default)  
+**Value:** Replace `<INGRESS_IP>` with the actual IP address of your ingress/load balancer (the external IP that nginx/Traefik binds to).
+
+### Apex Record
+Ensure the apex domain also resolves:
+
+```
+owt.craazzzyyfoxx.me  A  <INGRESS_IP>
+```
+
+**Purpose:** Allows direct access to `https://owt.craazzzyyfoxx.me` (the primary platform zone), as well as workspace subdomains (`<workspace>.owt.craazzzyyfoxx.me`).
+
+### Verification
+```bash
+# Verify wildcard resolves
+nslookup test-tenant.owt.craazzzyyfoxx.me
+nslookup owt.craazzzyyfoxx.me
+
+# Expected output: both should return <INGRESS_IP>
+```
+
+---
+
+## 2. TLS / HTTPS (External Traefik)
+
+The TLS termination is handled by Traefik (external to the docker-compose stack, running on the production host). The Gateway and nginx services receive plain HTTP from Traefik and do not manage certificates.
+
+### Wildcard Certificate via DNS-01 ACME
+
+**Rationale:** A wildcard certificate for `*.owt.craazzzyyfoxx.me` covers both the apex and all subdomains, avoiding Let's Encrypt's per-domain rate limits and simplifying multi-tenant DNS validation.
+
+#### Prerequisites
+
+1. **DNS API Credentials**: Your DNS provider must support API-driven ACME DNS-01 challenges.
+   - Supported providers: CloudFlare, Route53, Azure DNS, Linode, DigitalOcean, etc.
+   - Store credentials securely (e.g., in a `.env` file for Traefik).
+
+2. **Traefik ACME Configuration** (host-level, `/root/overwatch-tournaments/traefik.yml` or equivalent):
+
+```yaml
+certificatesResolvers:
+  dns-acme:
+    acme:
+      email: admin@example.com
+      storage: ./acme.json
+      dnsChallenge:
+        provider: cloudflare  # or route53, azure, etc.
+        resolvers:
+          - 1.1.1.1:53
+          - 8.8.8.8:53
+      
+      entryPoint: web  # or appropriate entrypoint
+```
+
+3. **Provider-Specific Environment Variables**: Add credentials for your DNS provider:
+
+   **CloudFlare example:**
+   ```bash
+   export CF_API_EMAIL="your-email@example.com"
+   export CF_API_KEY="your-global-api-key"
+   # or
+   export CF_DNS_API_TOKEN="your-dns-only-token"
+   ```
+
+   **Route53 example:**
+   ```bash
+   export AWS_ACCESS_KEY_ID="..."
+   export AWS_SECRET_ACCESS_KEY="..."
+   export AWS_REGION="us-east-1"
+   ```
+
+#### Certificate Issuance
+
+Traefik will automatically request and renew the certificate when a matching route (host rule) is first accessed:
+
+```yaml
+# In Traefik router/service config
+- Host(`owt.craazzzyyfoxx.me`) || HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.owt.craazzzyyfoxx.me`)
+- CertResolver: dns-acme
+```
+
+**Traefik will:**
+1. Create a DNS TXT record in your domain via API (DNS-01 challenge)
+2. Validate the record with Let's Encrypt
+3. Issue the wildcard certificate
+4. Store it in `./acme.json`
+
+**Expected output in Traefik logs:**
+```
+[dns] acme: Using DNS provider (cloudflare)
+[acme] Registering account...
+[acme] Sending certificate request...
+[acme] Cert obtained for *.owt.craazzzyyfoxx.me
+```
+
+#### Renewal
+
+Traefik automatically renews certificates 30 days before expiry. Monitor Traefik logs to confirm renewals are working.
+
+#### Manual Renewal (if needed)
+
+```bash
+# On the host running Traefik
+traefik --acme.onHostRule=true --entryPoints.web.address=:80 \
+  --certificatesResolvers.dns-acme.acme.dnsChallenge.provider=cloudflare
+```
+
+---
+
+## 3. OAuth Provider Registration
+
+Each OAuth provider (Discord, Twitch, Battle.net) requires the **single redirect URI** to be registered in their developer console.
+
+### Redirect URI
+```
+https://owt.craazzzyyfoxx.me/auth/callback
+```
+
+**Note:** This is the **only** callback for all tenants. The identity-svc validates the session and workspace context internally; the OAuth flow always returns to this canonical URL.
+
+### Discord Developer Console
+
+1. Go to https://discord.com/developers/applications
+2. Select or create your application
+3. Navigate to **OAuth2 > General**
+4. Under **Redirects**, add:
+   ```
+   https://owt.craazzzyyfoxx.me/auth/callback
+   ```
+5. Save and note the **Client ID** and **Client Secret** → environment variables (`DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` in `backend/env/auth.env`)
+
+### Twitch Developer Console
+
+1. Go to https://dev.twitch.tv/console/apps
+2. Select or create your application
+3. Navigate to **OAuth Redirect URLs**
+4. Add:
+   ```
+   https://owt.craazzzyyfoxx.me/auth/callback
+   ```
+5. Save and note **Client ID** and **Client Secret** → environment variables (`TWITCH_CLIENT_ID`, `TWITCH_CLIENT_SECRET`)
+
+### Battle.net Developer Console
+
+1. Go to https://develop.battle.net/applications
+2. Select or create your application
+3. Navigate to **OAuth**
+4. Under **Redirect URIs**, add:
+   ```
+   https://owt.craazzzyyfoxx.me/auth/callback
+   ```
+5. Save and note **Client ID** and **Client Secret** → environment variables (`BATTLENET_CLIENT_ID`, `BATTLENET_CLIENT_SECRET`)
+
+### Environment Variables
+
+Update `backend/env/auth.env` (or `.env.production` for Docker) with:
+
+```bash
+DISCORD_CLIENT_ID=<your-discord-client-id>
+DISCORD_CLIENT_SECRET=<your-discord-client-secret>
+
+TWITCH_CLIENT_ID=<your-twitch-client-id>
+TWITCH_CLIENT_SECRET=<your-twitch-client-secret>
+
+BATTLENET_CLIENT_ID=<your-battlenet-client-id>
+BATTLENET_CLIENT_SECRET=<your-battlenet-client-secret>
+BATTLENET_REGION=eu
+
+OAUTH_REDIRECT=https://owt.craazzzyyfoxx.me/auth/callback
+```
+
+---
+
+## 4. Verification Checklist
+
+After DNS, TLS, and OAuth provider registration are complete, run the following checks:
+
+### [ ] DNS Resolution
+
+```bash
+# Verify wildcard resolves
+nslookup dev.owt.craazzzyyfoxx.me
+nslookup prod.owt.craazzzyyfoxx.me
+nslookup owt.craazzzyyfoxx.me
+
+# Expected: all return <INGRESS_IP>
+```
+
+### [ ] TLS Certificate
+
+```bash
+# Check certificate validity for the apex and a subdomain
+curl -vI https://owt.craazzzyyfoxx.me/api/health
+curl -vI https://test-tenant.owt.craazzzyyfoxx.me/api/health
+
+# Expected:
+# - HTTP/2 200 or 3xx
+# - Subject: CN = *.owt.craazzzyyfoxx.me (in certificate details)
+# - Issuer: Let's Encrypt
+```
+
+### [ ] OAuth Login Round-Trip
+
+1. Navigate to `https://owt.craazzzyyfoxx.me` in a browser
+2. Click **Login** → select **Discord** (or Twitch/Battle.net)
+3. Approve scopes in the OAuth provider's consent screen
+4. Verify you are redirected back to `https://owt.craazzzyyfoxx.me/auth/callback`
+5. Check that you are authenticated and can see your profile
+
+### [ ] Subdomain Login & Cookie Propagation
+
+1. Create or navigate to a workspace accessible at `https://<workspace>.owt.craazzzyyfoxx.me`
+2. Verify the page loads (workspace resolver accepts the subdomain)
+3. Perform an OAuth login as above
+4. Verify that cookies are set with the domain `.owt.craazzzyyfoxx.me` (domain-wide, not subdomain-specific):
+   - Browser DevTools > Application > Cookies
+   - Look for `owt_access_token`, `owt_refresh_token`, `owt-workspace-id`
+   - Each should have **Domain: `.owt.craazzzyyfoxx.me`** (leading dot)
+5. Navigate to another subdomain (e.g., `https://<other-workspace>.owt.craazzzyyfoxx.me`)
+6. Verify that you remain logged in (session carries across subdomains)
+
+### [ ] WebSocket Origin Validation
+
+1. Open browser DevTools > Network > WS (filter for WebSocket)
+2. On the workspace subdomain, perform any action that opens a WebSocket (e.g., real-time updates)
+3. Verify the WebSocket connects successfully (not rejected with 403 Forbidden)
+4. Check that the gateway accepted the `Origin` header from the subdomain
+
+### Summary
+
+If all checks pass:
+- ✅ DNS wildcards and apex resolve correctly
+- ✅ TLS certificate covers `*.owt.craazzzyyfoxx.me` and is valid
+- ✅ OAuth callbacks work and redirect to the canonical URL
+- ✅ Workspace subdomains resolve and load
+- ✅ Sessions propagate across subdomains
+- ✅ WebSocket connections are allowed
+
+---
+
+## Rollback / Troubleshooting
+
+### DNS Propagation Delay
+If DNS changes don't resolve immediately:
+- Wait 5–10 minutes for TTL expiry
+- Flush local DNS cache: `ipconfig /flushdns` (Windows) or `sudo dscacheutil -flushcache` (macOS)
+- Use `dig` or `nslookup` with a public resolver: `nslookup owt.craazzzyyfoxx.me 8.8.8.8`
+
+### TLS Certificate Errors
+- Check Traefik logs: `docker logs traefik` or `journalctl -u traefik` (systemd)
+- Ensure DNS provider credentials are set and correct
+- Clear `acme.json` and restart Traefik to force a re-issue (caution: rate limits may apply)
+
+### OAuth Redirect Loop
+- Verify `OAUTH_REDIRECT` in `backend/env/auth.env` matches the provider console entry exactly
+- Check that provider credentials (`DISCORD_CLIENT_ID`, etc.) are correct
+- Inspect gateway/identity-svc logs for state validation errors
+
+### WebSocket Connection Refused
+- Verify `GATEWAY_WS_ALLOWED_ORIGINS` in `backend/env/common.env.example` is set to include the workspace subdomain
+- Restart the gateway service after env changes
+- Check gateway logs for `Origin mismatch` or similar errors
+
+---
+
+## References
+
+- **Traefik ACME & DNS-01:** https://doc.traefik.io/traefik/https/acme/
+- **Let's Encrypt Rate Limits:** https://letsencrypt.org/docs/rate-limits/
+- **OAuth 2.0 Redirect URI Security:** https://oauth.net/2/redirect-uris/

--- a/docs/superpowers/plans/2026-07-06-workspace-subdomains-phase1.md
+++ b/docs/superpowers/plans/2026-07-06-workspace-subdomains-phase1.md
@@ -1,0 +1,1209 @@
+# Workspace Subdomains (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve each opted-in workspace at its own subdomain `{subdomain}.owt.craazzzyyfoxx.me` as a white-label site (host = workspace), with OAuth, SSO across subdomains, and per-workspace SEO working end-to-end.
+
+**Architecture:** A Next.js `middleware.ts` resolves the request host → workspace via a new cached `rpc.app.workspaces.by_host` and injects `x-owt-workspace-id` (host beats cookie). OAuth funnels through one registered apex callback carrying the origin in a signed HMAC state; session cookies are set `Domain=.owt.craazzzyyfoxx.me` so login carries across all subdomains. Metadata becomes per-request per-workspace.
+
+**Tech Stack:** Python 3 (FastStream RPC, SQLAlchemy, Alembic, Pydantic v2, pytest) · Next.js App Router (TypeScript, `bun test`) · Go gateway (`go test`).
+
+**Spec:** `docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md`. This plan is **Phase 1 only** (subdomains). Phase 2 (custom domains, SSO ticket handoff, on-demand TLS) gets its own plan.
+
+## Global Constraints
+
+- Platform zone: `owt.craazzzyyfoxx.me`. Apex + `www` = multi-workspace platform. `{label}.owt.craazzzyyfoxx.me` = tenant (white-label) host.
+- Subdomain label rule: `^[a-z0-9-]+$`, length 1–63, not in the reserved set: `www api auth admin app assets static cdn mail ws`.
+- Session cookies: written under `owt_*` names, read as `owt_* ?? aqt_*` (compat, no forced logout). Session cookies get `Domain=.owt.craazzzyyfoxx.me`.
+- Single OAuth callback (all providers, all origins): `https://owt.craazzzyyfoxx.me/auth/callback`.
+- White-label lock: on a tenant host, `x-owt-workspace-id` overrides the `owt-workspace-id` cookie; switcher + "communities" hidden.
+- Typed columns only (no JSON bags). Follow existing patterns (branding shipped the same way — [[project_workspace_branding]]).
+- Lint/format: Python `ruff`/`black` via `uv run`; TS `eslint`; Go `gofmt`/`go vet`. Tests: `uv run pytest`, `bun test <path>`, `go test`.
+
+---
+
+### Task 1: Hostname / subdomain utility (backend, shared)
+
+**Files:**
+- Create: `backend/shared/tenancy/hostnames.py`
+- Create: `backend/shared/tenancy/__init__.py` (if missing — check first; `Workspace` already lives in `backend/shared/models/tenancy/`, but `shared/tenancy/` as a non-model package is new)
+- Test: `backend/app-service/tests/test_hostnames.py`
+
+**Interfaces:**
+- Produces:
+  - `PLATFORM_ZONE: str = "owt.craazzzyyfoxx.me"`
+  - `RESERVED_SUBDOMAINS: frozenset[str]`
+  - `validate_subdomain_label(label: str) -> str` — normalizes (lower/strip) and returns it, raises `ValueError` on invalid/reserved.
+  - `subdomain_from_host(host: str) -> str | None` — returns the label if `host` is `{label}.{PLATFORM_ZONE}` and label is a single segment (not the apex/`www`), else `None`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/app-service/tests/test_hostnames.py
+import pytest
+
+from shared.tenancy.hostnames import (
+    PLATFORM_ZONE,
+    subdomain_from_host,
+    validate_subdomain_label,
+)
+
+
+def test_platform_zone():
+    assert PLATFORM_ZONE == "owt.craazzzyyfoxx.me"
+
+
+@pytest.mark.parametrize("label", ["team-a", "owcs", "a", "x1y2"])
+def test_validate_accepts_valid_labels(label):
+    assert validate_subdomain_label(label.upper()) == label  # normalizes case
+
+
+@pytest.mark.parametrize("bad", ["team_a", "-team", "te am", "", "a" * 64, "café"])
+def test_validate_rejects_malformed(bad):
+    with pytest.raises(ValueError):
+        validate_subdomain_label(bad)
+
+
+@pytest.mark.parametrize("reserved", ["www", "api", "auth", "admin", "ws"])
+def test_validate_rejects_reserved(reserved):
+    with pytest.raises(ValueError):
+        validate_subdomain_label(reserved)
+
+
+def test_subdomain_from_host_extracts_label():
+    assert subdomain_from_host("team-a.owt.craazzzyyfoxx.me") == "team-a"
+    assert subdomain_from_host("TEAM-A.owt.craazzzyyfoxx.me") == "team-a"
+
+
+def test_subdomain_from_host_ignores_apex_www_and_foreign():
+    assert subdomain_from_host("owt.craazzzyyfoxx.me") is None
+    assert subdomain_from_host("www.owt.craazzzyyfoxx.me") is None
+    assert subdomain_from_host("a.b.owt.craazzzyyfoxx.me") is None  # multi-segment
+    assert subdomain_from_host("evil.com") is None
+    assert subdomain_from_host("team-a.owt.craazzzyyfoxx.me:443") == "team-a"  # port stripped
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/app-service && uv run pytest tests/test_hostnames.py -q`
+Expected: FAIL — `ModuleNotFoundError: shared.tenancy.hostnames`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/shared/tenancy/hostnames.py
+"""Platform-zone hostname helpers for host->workspace resolution.
+
+Phase 1 handles subdomains under the platform zone. Custom domains (Phase 2)
+match a separate column and are resolved elsewhere.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = (
+    "PLATFORM_ZONE",
+    "RESERVED_SUBDOMAINS",
+    "validate_subdomain_label",
+    "subdomain_from_host",
+)
+
+PLATFORM_ZONE = "owt.craazzzyyfoxx.me"
+
+RESERVED_SUBDOMAINS = frozenset(
+    {"www", "api", "auth", "admin", "app", "assets", "static", "cdn", "mail", "ws"}
+)
+
+_LABEL_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def validate_subdomain_label(label: str) -> str:
+    normalized = label.strip().lower()
+    if not (1 <= len(normalized) <= 63):
+        raise ValueError("Subdomain must be 1-63 characters")
+    if not _LABEL_RE.fullmatch(normalized):
+        raise ValueError("Subdomain may contain only a-z, 0-9 and hyphen")
+    if normalized.startswith("-") or normalized.endswith("-"):
+        raise ValueError("Subdomain may not start or end with a hyphen")
+    if normalized in RESERVED_SUBDOMAINS:
+        raise ValueError(f"Subdomain '{normalized}' is reserved")
+    return normalized
+
+
+def subdomain_from_host(host: str) -> str | None:
+    if not host:
+        return None
+    hostname = host.strip().lower().split(":", 1)[0]  # drop port
+    suffix = "." + PLATFORM_ZONE
+    if not hostname.endswith(suffix):
+        return None
+    label = hostname[: -len(suffix)]
+    if not label or "." in label:  # apex has empty label; multi-segment rejected
+        return None
+    if label == "www" or label in RESERVED_SUBDOMAINS:
+        return None
+    return label
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/app-service && uv run pytest tests/test_hostnames.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd backend && uv run ruff check shared/tenancy/hostnames.py && uv run ruff format shared/tenancy/hostnames.py
+git add backend/shared/tenancy/ backend/app-service/tests/test_hostnames.py
+git commit -m "feat(tenancy): add platform-zone hostname + subdomain-label helpers"
+```
+
+---
+
+### Task 2: Workspace columns + migration
+
+**Files:**
+- Modify: `backend/shared/models/tenancy/workspace.py` (add columns after `is_active`/branding block)
+- Create: `backend/migrations/versions/wsdomain0001_add_workspace_subdomain_seo.py`
+
+**Interfaces:**
+- Produces `Workspace.subdomain`, `Workspace.seo_title`, `Workspace.seo_description` (all `Mapped[str | None]`), `subdomain` uniquely indexed.
+
+- [ ] **Step 1: Confirm the current alembic head**
+
+Run:
+```bash
+cd backend/migrations/versions && python - <<'PY'
+import re, pathlib
+revs, downs = {}, set()
+for p in pathlib.Path('.').glob('*.py'):
+    t = p.read_text(encoding='utf-8', errors='ignore')
+    rm = re.search(r'^revision(?::\s*[^=]+)?\s*=\s*["\']([^"\']+)["\']', t, re.M)
+    if rm: revs[rm.group(1)] = p.name
+    m = re.search(r'^down_revision\b[^=]*=\s*', t, re.M)
+    if m:
+        rest = t[m.end():]
+        seg = rest[:rest.index(')')+1] if rest.lstrip().startswith('(') else rest.split('\n',1)[0]
+        downs.update(re.findall(r'["\']([^"\']+)["\']', seg))
+print("HEADS:", [r for r in revs if r not in downs])
+PY
+```
+Expected: `HEADS: ['wsbrand0001']` (the branding migration). If different, use the printed head as `down_revision`.
+
+- [ ] **Step 2: Add the model columns**
+
+In `backend/shared/models/tenancy/workspace.py`, after the `brand_surface` column, add:
+
+```python
+    # White-label multi-domain (Phase 1: subdomains). See
+    # docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md.
+    subdomain: Mapped[str | None] = mapped_column(String(63), unique=True, index=True, nullable=True)
+    seo_title: Mapped[str | None] = mapped_column(String(), nullable=True)
+    seo_description: Mapped[str | None] = mapped_column(String(), nullable=True)
+```
+
+- [ ] **Step 3: Write the migration**
+
+```python
+# backend/migrations/versions/wsdomain0001_add_workspace_subdomain_seo.py
+"""add workspace subdomain + seo columns
+
+Revision ID: wsdomain0001
+Revises: wsbrand0001
+Create Date: 2026-07-06
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "wsdomain0001"
+down_revision: str | None = "wsbrand0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("workspace", sa.Column("subdomain", sa.String(length=63), nullable=True))
+    op.add_column("workspace", sa.Column("seo_title", sa.String(), nullable=True))
+    op.add_column("workspace", sa.Column("seo_description", sa.String(), nullable=True))
+    op.create_index("ix_workspace_subdomain", "workspace", ["subdomain"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workspace_subdomain", table_name="workspace")
+    op.drop_column("workspace", "seo_description")
+    op.drop_column("workspace", "seo_title")
+    op.drop_column("workspace", "subdomain")
+```
+
+- [ ] **Step 4: Verify the migration renders offline**
+
+Run: `cd backend/app-service && uv run alembic upgrade wsbrand0001:wsdomain0001 --sql`
+Expected: prints `ALTER TABLE workspace ADD COLUMN subdomain ...` + the unique index, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/shared/models/tenancy/workspace.py backend/migrations/versions/wsdomain0001_add_workspace_subdomain_seo.py
+git commit -m "feat(workspace): add subdomain + seo columns"
+```
+
+---
+
+### Task 3: Schemas + frontend type
+
+**Files:**
+- Modify: `backend/app-service/src/schemas/workspace.py` (`WorkspaceRead`, `WorkspaceUpdate`)
+- Modify: `frontend/src/types/workspace.types.ts` (`Workspace`)
+- Test: `backend/app-service/tests/test_workspace_branding_schema.py` (extend the existing file)
+
+**Interfaces:**
+- Consumes: `validate_subdomain_label` (Task 1).
+- Produces: `WorkspaceRead.{subdomain,seo_title,seo_description}`, `WorkspaceUpdate.{subdomain,seo_title,seo_description}` with subdomain validated.
+
+- [ ] **Step 1: Write the failing test** (append to `test_workspace_branding_schema.py`)
+
+```python
+def test_update_accepts_valid_subdomain():
+    model = schemas.WorkspaceUpdate(subdomain="Team-A")
+    assert model.subdomain == "team-a"  # normalized
+
+
+@pytest.mark.parametrize("bad", ["team_a", "www", "-x", "a" * 64])
+def test_update_rejects_bad_subdomain(bad):
+    with pytest.raises(ValidationError):
+        schemas.WorkspaceUpdate(subdomain=bad)
+
+
+def test_read_exposes_domain_seo_fields():
+    fields = schemas.WorkspaceRead.model_fields
+    for name in ("subdomain", "seo_title", "seo_description"):
+        assert name in fields
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/app-service && uv run pytest tests/test_workspace_branding_schema.py -q`
+Expected: FAIL — `WorkspaceUpdate` has no `subdomain`.
+
+- [ ] **Step 3: Implement the schema changes**
+
+In `backend/app-service/src/schemas/workspace.py`, add imports + fields:
+
+```python
+from pydantic import field_validator
+
+from shared.tenancy.hostnames import validate_subdomain_label
+```
+
+In `WorkspaceRead` (after branding fields):
+
+```python
+    subdomain: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
+```
+
+In `WorkspaceUpdate` (after branding fields):
+
+```python
+    subdomain: str | None = None
+    seo_title: str | None = None
+    seo_description: str | None = None
+
+    @field_validator("subdomain")
+    @classmethod
+    def _validate_subdomain(cls, value: str | None) -> str | None:
+        if value is None or value == "":
+            return None
+        return validate_subdomain_label(value)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend/app-service && uv run pytest tests/test_workspace_branding_schema.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Update the frontend type**
+
+In `frontend/src/types/workspace.types.ts`, add to `interface Workspace` (after branding fields):
+
+```typescript
+  subdomain: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app-service/src/schemas/workspace.py backend/app-service/tests/test_workspace_branding_schema.py frontend/src/types/workspace.types.ts
+git commit -m "feat(workspace): expose subdomain + seo in schemas and frontend type"
+```
+
+---
+
+### Task 4: `get_by_subdomain` service + `by_host` RPC
+
+**Files:**
+- Modify: `backend/app-service/src/services/workspace/service.py` (add `get_by_subdomain`)
+- Modify: `backend/shared/repository` workspace repo (add `get_by_subdomain` mirroring `get_by_slug`) — locate via `grep -rn "def get_by_slug" backend/shared/repository`
+- Modify: `backend/app-service/src/rpc/workspaces.py` (add `by_host` subscriber)
+- Test: `backend/app-service/tests/api/test_workspaces_by_host.py` (integration, DB-gated like existing `rpc` tests)
+
+**Interfaces:**
+- Consumes: `subdomain_from_host` (Task 1), `Workspace.subdomain` (Task 2).
+- Produces: `service.get_by_subdomain(session, label) -> Workspace | None`; RPC topic `rpc.app.workspaces.by_host` accepting `{query: {host: [str]}}`, returning envelope `{ok, data: {workspace_id, slug} | None}`.
+
+- [ ] **Step 1: Add the repository + service lookup**
+
+In the workspace repository (next to `get_by_slug`):
+
+```python
+    async def get_by_subdomain(self, session: AsyncSession, subdomain: str) -> Workspace | None:
+        result = await session.execute(select(Workspace).where(Workspace.subdomain == subdomain))
+        return result.scalar_one_or_none()
+```
+
+In `backend/app-service/src/services/workspace/service.py` (next to `get_by_slug`):
+
+```python
+async def get_by_subdomain(session: AsyncSession, subdomain: str) -> models.Workspace | None:
+    return await _workspace_repo.get_by_subdomain(session, subdomain)
+```
+
+- [ ] **Step 2: Add the `by_host` RPC handler**
+
+In `backend/app-service/src/rpc/workspaces.py`, inside `register(broker, logger)` (near the existing public `list`/`get` handlers), add:
+
+```python
+    @broker.subscriber("rpc.app.workspaces.by_host")
+    async def by_host(data: dict, msg: RabbitMessage) -> dict:
+        # Public, cached: host -> {workspace_id, slug}. Phase 1 matches the
+        # platform-zone subdomain only; custom domains are Phase 2.
+        host = _first_query(data, "host")  # existing helper for query params
+        if not host:
+            return {"ok": True, "data": None}
+        label = subdomain_from_host(host)
+        if label is None:
+            return {"ok": True, "data": None}
+        async with db.async_session_maker() as session:
+            workspace = await workspace_service.get_by_subdomain(session, label)
+        if workspace is None:
+            return {"ok": True, "data": None}
+        return {"ok": True, "data": {"workspace_id": workspace.id, "slug": workspace.slug}}
+```
+
+Add imports at the top of the module: `from shared.tenancy.hostnames import subdomain_from_host`. Reuse the module's existing query-extraction helper; if none exists, read `data.get("query", {}).get("host", [None])[0]`.
+
+- [ ] **Step 3: Expose the route through the gateway**
+
+Add a `RouteSpec` for `GET /api/v1/workspaces/by-host` → `rpc.app.workspaces.by_host` in the gateway route table (find the workspace routes: `grep -rn "workspaces" gateway/internal/*/`). Follow the existing public workspace `list` route (no auth). Map query `host`.
+
+- [ ] **Step 4: Write the integration test**
+
+```python
+# backend/app-service/tests/api/test_workspaces_by_host.py
+import pytest
+
+from src.rpc import workspaces as workspaces_rpc
+
+
+@pytest.mark.integration
+def test_by_host_unknown_returns_null(rpc):
+    harness = rpc  # session-scoped harness (skips if DB unreachable)
+    harness.register(workspaces_rpc)
+    res = harness.call_sync(
+        "rpc.app.workspaces.by_host",
+        {"query": {"host": ["nope.owt.craazzzyyfoxx.me"]}},
+    )
+    assert res["ok"] is True
+    assert res["data"] is None
+```
+
+(Full round-trip with a seeded subdomain is exercised in E2E; the unit of resolution logic is covered by Task 1.)
+
+- [ ] **Step 5: Run + commit**
+
+Run: `cd backend/app-service && uv run pytest tests/api/test_workspaces_by_host.py -q` (skips cleanly without a DB).
+
+```bash
+git add backend/shared/repository backend/app-service/src/services/workspace/service.py backend/app-service/src/rpc/workspaces.py backend/app-service/tests/api/test_workspaces_by_host.py gateway/
+git commit -m "feat(workspace): add by_host resolver (subdomain) rpc + route"
+```
+
+---
+
+### Task 5: Frontend host parsing utility
+
+**Files:**
+- Create: `frontend/src/lib/host.ts`
+- Test: `frontend/src/lib/host.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `PLATFORM_ZONE = "owt.craazzzyyfoxx.me"`
+  - `type HostResolution = { mode: "platform" } | { mode: "tenant"; subdomain: string }`
+  - `resolveHost(host: string | null | undefined): HostResolution` — apex/`www`/empty → platform; `{label}.PLATFORM_ZONE` (single segment, non-reserved) → tenant; anything else (foreign host in dev, multi-segment) → platform (safe default; middleware treats "no workspace found" as 404 only after a lookup miss).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/src/lib/host.test.ts
+import { describe, expect, it } from "bun:test";
+import { PLATFORM_ZONE, resolveHost } from "@/lib/host";
+
+describe("resolveHost", () => {
+  it("treats apex + www as platform", () => {
+    expect(resolveHost(PLATFORM_ZONE)).toEqual({ mode: "platform" });
+    expect(resolveHost(`www.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+    expect(resolveHost(null)).toEqual({ mode: "platform" });
+  });
+
+  it("extracts a tenant subdomain", () => {
+    expect(resolveHost(`team-a.${PLATFORM_ZONE}`)).toEqual({ mode: "tenant", subdomain: "team-a" });
+    expect(resolveHost(`TEAM-A.${PLATFORM_ZONE}:443`)).toEqual({ mode: "tenant", subdomain: "team-a" });
+  });
+
+  it("rejects reserved + multi-segment labels as platform", () => {
+    expect(resolveHost(`api.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+    expect(resolveHost(`a.b.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && bun test src/lib/host.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// frontend/src/lib/host.ts
+export const PLATFORM_ZONE = "owt.craazzzyyfoxx.me";
+
+const RESERVED = new Set([
+  "www", "api", "auth", "admin", "app", "assets", "static", "cdn", "mail", "ws",
+]);
+
+export type HostResolution = { mode: "platform" } | { mode: "tenant"; subdomain: string };
+
+export function resolveHost(host: string | null | undefined): HostResolution {
+  if (!host) return { mode: "platform" };
+  const hostname = host.trim().toLowerCase().split(":")[0];
+  const suffix = `.${PLATFORM_ZONE}`;
+  if (!hostname.endsWith(suffix)) return { mode: "platform" };
+  const label = hostname.slice(0, -suffix.length);
+  if (!label || label.includes(".") || RESERVED.has(label)) return { mode: "platform" };
+  return { mode: "tenant", subdomain: label };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && bun test src/lib/host.test.ts`
+Expected: PASS (4 assertions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/host.ts frontend/src/lib/host.test.ts
+git commit -m "feat(host): add platform-zone host resolver"
+```
+
+---
+
+### Task 6: `getByHost` service + Next.js middleware
+
+**Files:**
+- Modify: `frontend/src/services/workspace.service.ts` (add `getByHost`)
+- Create: `frontend/src/middleware.ts`
+
+**Interfaces:**
+- Consumes: `resolveHost` (Task 5), `by-host` route (Task 4).
+- Produces: request header `x-owt-workspace-id` on tenant hosts; the `x-owt-host-mode` header (`platform` | `tenant`) for downstream server components.
+
+- [ ] **Step 1: Add the service method**
+
+In `frontend/src/services/workspace.service.ts`:
+
+```typescript
+  static async getByHost(host: string): Promise<{ workspace_id: number; slug: string } | null> {
+    const res = await apiFetch(`/api/v1/workspaces/by-host`, {
+      query: { host },
+      skipWorkspace: true,
+    });
+    return res.json();
+  }
+```
+
+- [ ] **Step 2: Write the middleware**
+
+```typescript
+// frontend/src/middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { resolveHost } from "@/lib/host";
+
+// Small in-memory TTL cache: the host->workspace map is tiny and rarely changes.
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, { id: number | null; at: number }>();
+
+async function resolveWorkspaceId(origin: string, subdomain: string): Promise<number | null> {
+  const host = `${subdomain}.${"owt.craazzzyyfoxx.me"}`;
+  const cached = cache.get(host);
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.id;
+  try {
+    const res = await fetch(`${origin}/api/v1/workspaces/by-host?host=${encodeURIComponent(host)}`, {
+      headers: { accept: "application/json" },
+    });
+    const data = res.ok ? await res.json() : null;
+    const id = data?.workspace_id ?? null;
+    cache.set(host, { id, at: now });
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const resolution = resolveHost(host);
+
+  if (resolution.mode === "platform") {
+    return NextResponse.next();
+  }
+
+  const workspaceId = await resolveWorkspaceId(request.nextUrl.origin, resolution.subdomain);
+  if (workspaceId === null) {
+    return NextResponse.rewrite(new URL("/not-configured", request.url), { status: 404 });
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("x-owt-workspace-id", String(workspaceId));
+  headers.set("x-owt-host-mode", "tenant");
+  return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+  // Skip static assets + Next internals; run on pages + API-relative routes.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|webp|svg|ico)).*)"],
+};
+```
+
+- [ ] **Step 3: Create the 404 "not configured" page**
+
+```tsx
+// frontend/src/app/(site)/not-configured/page.tsx
+export default function NotConfigured() {
+  return (
+    <div className="mx-auto max-w-md py-24 text-center">
+      <h1 className="text-2xl font-semibold">Workspace not configured</h1>
+      <p className="mt-2 text-muted-foreground">
+        This address is not linked to a workspace yet.
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Verify build + manual smoke**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+Manual (after Task 17 env + a seeded subdomain): `curl -H "x-forwarded-host: team-a.owt.craazzzyyfoxx.me" http://localhost:3000/` returns the workspace-scoped page; an unknown subdomain returns the not-configured page.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/services/workspace.service.ts frontend/src/middleware.ts "frontend/src/app/(site)/not-configured/page.tsx"
+git commit -m "feat(host): resolve host->workspace in middleware"
+```
+
+---
+
+### Task 7: Scope precedence (header beats cookie)
+
+**Files:**
+- Modify: `frontend/src/lib/api-fetch.ts` (`getServerWorkspaceId`, ~lines 77-85)
+
+**Interfaces:**
+- Consumes: `x-owt-workspace-id` header (Task 6).
+- Produces: server-side workspace scope preferring the host header over the cookie.
+
+- [ ] **Step 1: Modify `getServerWorkspaceId`**
+
+Replace the body so the host header wins over the cookie (white-label lock):
+
+```typescript
+const getServerWorkspaceId = cache(async (): Promise<string | undefined> => {
+  try {
+    const { headers, cookies } = await import("next/headers");
+    const headerId = (await headers()).get("x-owt-workspace-id");
+    if (headerId) return headerId;
+    const cookieStore = await cookies();
+    return cookieStore.get("owt-workspace-id")?.value ?? cookieStore.get("aqt-workspace-id")?.value;
+  } catch {
+    return undefined;
+  }
+});
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/api-fetch.ts
+git commit -m "feat(scope): prefer host workspace header over cookie (white-label lock)"
+```
+
+---
+
+### Task 8: Cookie rename (owt_*) with aqt_* read compat
+
+**Files:**
+- Modify: `gateway/internal/auth/auth.go` (`CookieName`, `extractToken`)
+- Test: `gateway/internal/auth/auth_cookie_test.go` (new)
+- Modify: `frontend/src/lib/auth-tokens.ts` (read `owt_* ?? aqt_*`, write `owt_*`)
+- Modify: `frontend/src/lib/api-fetch.ts` (`owt-workspace-id` already handled in Task 7)
+- Modify: `frontend/src/stores/workspace.store.ts` (write `owt-workspace-id`, read both)
+
+**Interfaces:**
+- Produces: canonical cookie names `owt_access_token`, `owt_refresh_token`, `owt-workspace-id`; reads fall back to `aqt_*`.
+
+- [ ] **Step 1: Write the failing Go test**
+
+```go
+// gateway/internal/auth/auth_cookie_test.go
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestExtractTokenPrefersOwtThenAqtCookie(t *testing.T) {
+	cases := []struct {
+		name    string
+		cookies []*http.Cookie
+		want    string
+	}{
+		{"owt only", []*http.Cookie{{Name: "owt_access_token", Value: "N"}}, "N"},
+		{"aqt fallback", []*http.Cookie{{Name: "aqt_access_token", Value: "O"}}, "O"},
+		{"owt wins", []*http.Cookie{{Name: "aqt_access_token", Value: "O"}, {Name: "owt_access_token", Value: "N"}}, "N"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			for _, ck := range c.cookies {
+				r.AddCookie(ck)
+			}
+			if got := extractToken(r); got != c.want {
+				t.Fatalf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd gateway && go test ./internal/auth/ -run TestExtractTokenPrefers -v`
+Expected: FAIL (aqt fallback + owt name not handled).
+
+- [ ] **Step 3: Update `auth.go`**
+
+```go
+// CookieName is the canonical access-token cookie; LegacyCookieName is read as a
+// fallback during the aqt->owt rename so existing sessions are not logged out.
+const CookieName = "owt_access_token"
+const LegacyCookieName = "aqt_access_token"
+```
+
+In `extractToken`, replace the single cookie read with:
+
+```go
+	for _, name := range []string{CookieName, LegacyCookieName} {
+		if c, err := r.Cookie(name); err == nil && c.Value != "" {
+			return strings.TrimSpace(strings.TrimPrefix(c.Value, "Bearer "))
+		}
+	}
+	return ""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd gateway && go test ./internal/auth/ -run TestExtractTokenPrefers -v`
+Expected: PASS
+
+- [ ] **Step 5: Update the frontend cookie sites**
+
+In `frontend/src/lib/auth-tokens.ts`: read `Cookies.get("owt_access_token") ?? Cookies.get("aqt_access_token")`; write only `owt_access_token`. In `frontend/src/stores/workspace.store.ts`: write `owt-workspace-id`; read `owt-workspace-id ?? aqt-workspace-id`. (The `WORKSPACE_COOKIE` constant becomes `"owt-workspace-id"`, plus a `LEGACY_WORKSPACE_COOKIE = "aqt-workspace-id"` used only in reads.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd gateway && gofmt -w internal/auth/auth.go internal/auth/auth_cookie_test.go
+git add gateway/internal/auth/ frontend/src/lib/auth-tokens.ts frontend/src/stores/workspace.store.ts
+git commit -m "feat(auth): rename cookies to owt_* with aqt_* read fallback"
+```
+
+---
+
+### Task 9: Signed OAuth state carries origin/redirect/action
+
+**Files:**
+- Modify: `backend/identity-service/src/services/oauth_service.py` (state encode/verify ~460-513, `generate_oauth_url` :513)
+- Modify: `backend/identity-service/src/services/oauth_flows.py` (`get_url` :27, `callback` :37 — thread through + echo decoded fields)
+- Modify: `backend/identity-service/src/core/config.py:77` (`OAUTH_REDIRECT` semantics: fixed apex callback)
+- Test: `backend/identity-service/tests/test_oauth_state.py` (new; check for an existing tests dir first)
+
+**Interfaces:**
+- Produces: state payload `{origin, redirect, action, provider, nonce, exp}`, HMAC-signed; `generate_oauth_url(provider, *, origin, redirect, action)`; `verify_state(state) -> StatePayload` (raises on bad HMAC / expired / replayed nonce); `oauth_callback` RPC response gains `origin`, `redirect`, `action`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/identity-service/tests/test_oauth_state.py
+import pytest
+
+from src.services.oauth_service import OAuthService  # adjust import to the state fns
+
+
+def test_state_roundtrip_carries_origin_and_action():
+    svc = OAuthService  # or the module-level encode/verify helpers
+    state = svc.encode_state(origin="https://team-a.owt.craazzzyyfoxx.me", redirect="/account", action="login", provider="discord")
+    payload = svc.verify_state(state)
+    assert payload.origin == "https://team-a.owt.craazzzyyfoxx.me"
+    assert payload.redirect == "/account"
+    assert payload.action == "login"
+    assert payload.provider == "discord"
+
+
+def test_state_rejects_tamper():
+    svc = OAuthService
+    state = svc.encode_state(origin="https://team-a.owt.craazzzyyfoxx.me", redirect="/", action="login", provider="discord")
+    with pytest.raises(ValueError):
+        svc.verify_state(state[:-2] + ("aa" if not state.endswith("aa") else "bb"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend/identity-service && uv run pytest tests/test_oauth_state.py -q`
+Expected: FAIL — `encode_state`/`verify_state` don't take these fields.
+
+- [ ] **Step 3: Implement the state payload**
+
+Extend the existing HMAC state helpers (`oauth_service.py:464-500`) to serialize a payload dict `{"o": origin, "r": redirect, "a": action, "p": provider, "n": nonce, "e": exp}` as `base64url(json).base64url(hmac_sha256(json, JWT_SECRET_KEY))`. `verify_state` splits, recomputes the HMAC (constant-time compare), checks `exp` (reject expired), and consumes `nonce` in Redis (single-use; reject on replay). Return a small dataclass `StatePayload(origin, redirect, action, provider)`.
+
+In `generate_oauth_url` (:513) accept `origin`, `redirect`, `action` and pass them to `encode_state`. Keep `redirect_uri = settings.OAUTH_REDIRECT` (now the fixed apex callback for authorize + exchange, unchanged mechanically — `oauth_service.py:68/167/281`).
+
+- [ ] **Step 4: Thread through flows + callback response**
+
+In `oauth_flows.get_url` (:27) accept `origin`/`redirect`/`action` from the request payload and forward. In `oauth_flows.callback` (:37) call `verify_state`, and include `origin`/`redirect`/`action` in the returned envelope alongside the token.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend/identity-service && uv run pytest tests/test_oauth_state.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend && uv run ruff check identity-service/src/services/oauth_service.py identity-service/src/services/oauth_flows.py
+git add backend/identity-service/
+git commit -m "feat(oauth): carry origin/redirect/action in signed state"
+```
+
+---
+
+### Task 10: Frontend OAuth start passes origin/redirect/action
+
+**Files:**
+- Modify: `frontend/src/lib/oauth-login.ts`
+- Modify: `frontend/src/services/auth.service.ts` (`getOAuthUrl` signature)
+
+**Interfaces:**
+- Consumes: `generate_oauth_url(origin, redirect, action)` (Task 9).
+- Produces: provider redirect with signed state; no `aqt_oauth_*` transient cookies.
+
+- [ ] **Step 1: Extend the auth service**
+
+In `frontend/src/services/auth.service.ts`, change `getOAuthUrl` to accept and forward params:
+
+```typescript
+  async getOAuthUrl(
+    provider: OAuthProviderName,
+    params: { origin: string; redirect: string; action: "login" | "link" },
+  ): Promise<{ url: string; state: string }> {
+    const res = await apiFetch(`/api/auth/oauth/${provider}/url`, {
+      query: { origin: params.origin, redirect: params.redirect, action: params.action },
+      skipWorkspace: true,
+    });
+    return res.json();
+  }
+```
+
+- [ ] **Step 2: Rewrite `startOAuthLogin`**
+
+Replace `frontend/src/lib/oauth-login.ts` body so the current host is the origin and no transient cookies are set:
+
+```typescript
+import { NextResponse } from "next/server";
+import { authService } from "@/services/auth.service";
+import type { OAuthProviderName } from "@/types/auth.types";
+
+export async function startOAuthLogin(request: Request, provider: OAuthProviderName): Promise<NextResponse> {
+  const { searchParams, origin } = new URL(request.url);
+  const nextParam = searchParams.get("next");
+  const action = searchParams.get("action") === "link" ? "link" : "login";
+
+  let redirect = action === "link" ? "/account" : "/";
+  if (nextParam) {
+    try {
+      const nextUrl = new URL(nextParam, origin);
+      if (nextUrl.origin === origin) redirect = nextUrl.pathname + nextUrl.search;
+    } catch {
+      if (nextParam.startsWith("/")) redirect = nextParam;
+    }
+  }
+
+  const { url } = await authService.getOAuthUrl(provider, { origin, redirect, action });
+  return NextResponse.redirect(url);
+}
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/oauth-login.ts frontend/src/services/auth.service.ts
+git commit -m "feat(oauth): pass origin/redirect/action into signed state on start"
+```
+
+---
+
+### Task 11: Frontend OAuth callback sets domain cookies + redirects to origin
+
+**Files:**
+- Modify: `frontend/src/lib/oauth-callback.ts`
+- Modify: `frontend/src/services/auth.service.ts` (`exchangeOAuthCode` return type gains `origin`/`redirect`/`action`)
+
+**Interfaces:**
+- Consumes: callback envelope `{token, origin, redirect, action}` (Task 9); `Domain=.owt.craazzzyyfoxx.me`.
+- Produces: session cookies valid across all subdomains; redirect to `origin + redirect`.
+
+- [ ] **Step 1: Define the cookie domain + origin allow-list helper**
+
+Add to `oauth-callback.ts`:
+
+```typescript
+import { resolveHost, PLATFORM_ZONE } from "@/lib/host";
+
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
+
+// Only redirect back to the platform apex or a valid tenant subdomain.
+function isAllowedOrigin(origin: string): boolean {
+  try {
+    const u = new URL(origin);
+    if (u.hostname === PLATFORM_ZONE) return true;
+    return resolveHost(u.hostname).mode === "tenant";
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: Rewrite the callback to use state fields + domain cookies**
+
+Replace the cookie-cross-check + redirect logic. Key changes: drop `expectedState`/`aqt_oauth_state`; get `origin`/`redirect`/`action` from the exchange response; set cookies with `domain: COOKIE_DOMAIN`; redirect to the origin host. Core of the success path:
+
+```typescript
+    const result = await authService.exchangeOAuthCode(provider, code, state, forwardedHeaders);
+    const origin = isAllowedOrigin(result.origin) ? result.origin : `https://${PLATFORM_ZONE}`;
+    const target = new URL(result.redirect || "/", origin);
+
+    const response = NextResponse.redirect(target);
+    response.cookies.set("owt_access_token", result.access_token, {
+      httpOnly: false, sameSite: "lax", secure: process.env.NODE_ENV === "production",
+      path: "/", domain: COOKIE_DOMAIN,
+      maxAge: getTokenMaxAgeSeconds(result.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS),
+    });
+    response.cookies.set("owt_refresh_token", result.refresh_token, {
+      httpOnly: true, sameSite: "lax", secure: process.env.NODE_ENV === "production",
+      path: "/", domain: COOKIE_DOMAIN, maxAge: 30 * 24 * 60 * 60,
+    });
+    return response;
+```
+
+For `action === "link"`, read the access token via `owt_access_token ?? aqt_access_token` (readable on the apex because it is now a domain cookie), then `authService.linkOAuth(...)` and redirect to `new URL("/account", origin)`.
+
+- [ ] **Step 3: Update `exchangeOAuthCode` return type**
+
+In `auth.service.ts`, type the response as `{ access_token: string; refresh_token: string; origin: string; redirect: string; action: "login" | "link" }`.
+
+- [ ] **Step 4: Verify typecheck + manual**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+Manual (after Task 17): log in on `team-a.owt.craazzzyyfoxx.me`; confirm the callback lands back on `team-a...` and the session is present on a second subdomain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/oauth-callback.ts frontend/src/services/auth.service.ts
+git commit -m "feat(oauth): domain cookies + origin redirect on callback"
+```
+
+---
+
+### Task 12: Per-host, per-workspace SEO metadata
+
+**Files:**
+- Create: `frontend/src/lib/site-metadata.ts` (host origin + workspace metadata resolver)
+- Modify: `frontend/src/app/layout.tsx` (static `metadata` → async `generateMetadata`)
+- Modify: section layouts with hardcoded `metadataBase` — `frontend/src/app/(site)/{owal,statistics,encounters,matches,teams,tournaments,tournaments/analytics}/layout.tsx`
+
+**Interfaces:**
+- Consumes: `x-owt-workspace-id` / `x-forwarded-host` headers; `workspaceService.getById`; `Workspace.{seo_title,seo_description,icon_url}`.
+- Produces: `resolveSiteMetadata(): Promise<{ name: string; description: string; origin: string; icon: string }>`.
+
+- [ ] **Step 1: Implement the resolver**
+
+```typescript
+// frontend/src/lib/site-metadata.ts
+import { headers } from "next/headers";
+import workspaceService from "@/services/workspace.service";
+import { SITE_NAME } from "@/config/site";
+
+export async function resolveSiteMetadata() {
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host") ?? "owt.craazzzyyfoxx.me";
+  const proto = h.get("x-forwarded-proto") ?? "https";
+  const origin = `${proto}://${host.split(",")[0].trim()}`;
+
+  const wsId = h.get("x-owt-workspace-id");
+  if (!wsId) {
+    return { name: SITE_NAME, description: `${SITE_NAME} — Overwatch tournament results & stats.`, origin, icon: "/favicon.ico" };
+  }
+  try {
+    const ws = await workspaceService.getById(Number(wsId));
+    return {
+      name: ws.seo_title ?? ws.name,
+      description: ws.seo_description ?? ws.description ?? `${ws.name} — tournaments`,
+      origin,
+      icon: ws.icon_url ?? "/favicon.ico",
+    };
+  } catch {
+    return { name: SITE_NAME, description: `${SITE_NAME}`, origin, icon: "/favicon.ico" };
+  }
+}
+```
+
+- [ ] **Step 2: Convert the root layout**
+
+In `frontend/src/app/layout.tsx`, replace the static `export const metadata` with:
+
+```typescript
+import type { Metadata } from "next";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, description, origin, icon } = await resolveSiteMetadata();
+  return {
+    title: name,
+    description,
+    metadataBase: new URL(origin),
+    icons: { icon },
+    openGraph: { title: name, description, url: origin, type: "website", siteName: name, locale: "en_US" },
+  };
+}
+```
+
+- [ ] **Step 3: Convert section layouts**
+
+For each section layout that hardcodes `metadataBase: new URL("https://aqt.craazzzyyfoxx.me")`, replace the static `metadata` with an async `generateMetadata` that calls `resolveSiteMetadata()` and sets `metadataBase: new URL(origin)` + `openGraph.siteName: name` (keep each section's own title/description text but base the URL/siteName on the resolver).
+
+- [ ] **Step 4: Verify typecheck + manual**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+Manual: view-source on `team-a.owt.craazzzyyfoxx.me` shows `<title>` + OG `site_name` = the workspace's `seo_title`, canonical host = that subdomain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/site-metadata.ts frontend/src/app/layout.tsx "frontend/src/app/(site)/"
+git commit -m "feat(seo): per-host per-workspace metadata"
+```
+
+---
+
+### Task 13: Host-scoped sitemap + robots
+
+**Files:**
+- Modify: `frontend/src/app/sitemap.ts`
+- Modify: `frontend/src/app/robots.ts`
+
+**Interfaces:**
+- Consumes: `resolveSiteMetadata` (Task 12).
+
+- [ ] **Step 1: Base both on the resolved origin**
+
+In `sitemap.ts` and `robots.ts`, replace `SITE_URL_OBJ` with the per-request `origin` from `resolveSiteMetadata()` (both files are already dynamic route handlers, so `headers()` is available). `robots.ts` `host` + `sitemap` fields use `origin`.
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+
+```bash
+git add frontend/src/app/sitemap.ts frontend/src/app/robots.ts
+git commit -m "feat(seo): host-scoped sitemap and robots"
+```
+
+---
+
+### Task 14: White-label UI gating (hide switcher + communities)
+
+**Files:**
+- Modify: `frontend/src/app/(site)/layout.tsx` (read `x-owt-host-mode`, pass `tenantMode` down)
+- Modify: `frontend/src/components/Header.tsx` (hide `WorkspaceSwitcher` in tenant mode)
+- Modify: `frontend/src/app/(site)/(home)/page.tsx` (hide communities list in tenant mode)
+
+**Interfaces:**
+- Consumes: `x-owt-host-mode` header (Task 6).
+
+- [ ] **Step 1: Surface tenant mode from the server layout**
+
+In `frontend/src/app/(site)/layout.tsx` read `const tenantMode = (await headers()).get("x-owt-host-mode") === "tenant";` and pass it to `<Header tenantMode={tenantMode} />`. (The layout is already async — it fetches branding.)
+
+- [ ] **Step 2: Gate the switcher**
+
+In `Header.tsx`, accept `tenantMode?: boolean` and render `WorkspaceSwitcher` only when `!tenantMode`.
+
+- [ ] **Step 3: Gate the communities section**
+
+In the home page, when tenant mode is active (read the header there too, or accept a prop), hide `CommunitiesSection` / "all communities" cards.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `cd frontend && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "^\.next/" | grep "error TS"` → expect empty.
+
+```bash
+git add "frontend/src/app/(site)/layout.tsx" frontend/src/components/Header.tsx "frontend/src/app/(site)/(home)/page.tsx"
+git commit -m "feat(white-label): hide switcher + communities on tenant hosts"
+```
+
+---
+
+### Task 15: Admin editor — subdomain + SEO fields
+
+**Files:**
+- Modify: `frontend/src/app/admin/workspaces/page.tsx` (extend the edit dialog + form types + service payload)
+- Modify: `frontend/src/services/workspace.service.ts` (`update` payload type)
+
+**Interfaces:**
+- Consumes: `WorkspaceUpdate` fields (Task 3).
+
+- [ ] **Step 1: Extend the update payload type**
+
+In `workspace.service.ts` `update(...)`, add `subdomain?: string | null; seo_title?: string | null; seo_description?: string | null;`.
+
+- [ ] **Step 2: Extend the admin edit form**
+
+In `admin/workspaces/page.tsx`, add to `WorkspaceUpdateFormData`: `subdomain?`, `seo_title?`, `seo_description?`. Populate them in `handleEdit` from `ws`. Add a "Domain & SEO" section to the edit dialog (mirror the branding section): a text input for `subdomain` (with helper text `{value}.owt.craazzzyyfoxx.me` and client-side `^[a-z0-9-]*$` filtering), and text inputs for `seo_title` / `seo_description`. Save via the existing `workspaceService.update`.
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `cd frontend && bunx eslint src/app/admin/workspaces/page.tsx src/services/workspace.service.ts` → 0 errors; `bunx tsc --noEmit ...` clean.
+
+```bash
+git add frontend/src/app/admin/workspaces/page.tsx frontend/src/services/workspace.service.ts
+git commit -m "feat(admin): edit workspace subdomain + seo"
+```
+
+---
+
+### Task 16: Gateway WS origin allows `*.owt.craazzzyyfoxx.me`
+
+**Files:**
+- Modify: `gateway/internal/ws/handler.go:47-58` (origin patterns)
+- Modify: `gateway/internal/config/config.go:130` (parse a default including the wildcard)
+- Test: `gateway/internal/ws/origin_test.go` (if the pattern check is extractable) or config test
+
+**Interfaces:**
+- Produces: WS accepts origins matching `*.owt.craazzzyyfoxx.me` + the apex, never `InsecureSkipVerify`.
+
+- [ ] **Step 1: Add the wildcard to the allowed origin patterns**
+
+Ensure `GATEWAY_WS_ALLOWED_ORIGINS` (config default + prod env) includes `owt.craazzzyyfoxx.me` and `*.owt.craazzzyyfoxx.me`. `coder/websocket` `OriginPatterns` supports `*` glob, so `accept.OriginPatterns` already matches subdomains once the pattern is present. Remove any `InsecureSkipVerify` fallback path (fail closed).
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `cd gateway && go build ./... && go test ./internal/ws/ ./internal/config/`
+
+```bash
+git add gateway/internal/ws/handler.go gateway/internal/config/config.go
+git commit -m "feat(ws): allow *.owt.craazzzyyfoxx.me origins"
+```
+
+---
+
+### Task 17: Config, env, and ops runbook
+
+**Files:**
+- Modify: `frontend/.env.example`, `docker-compose.production.yml` (`NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_SITE_NAME`)
+- Modify: `backend/env/auth.env.example` (`OAUTH_REDIRECT`)
+- Modify: `backend/env/common.env.example` (`GATEWAY_WS_ALLOWED_ORIGINS`)
+- Create: `docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md`
+
+**Interfaces:** none (config/docs).
+
+- [ ] **Step 1: Set canonical values**
+
+- `NEXT_PUBLIC_SITE_URL = https://owt.craazzzyyfoxx.me`
+- `OAUTH_REDIRECT = https://owt.craazzzyyfoxx.me/auth/callback`
+- `GATEWAY_WS_ALLOWED_ORIGINS = https://owt.craazzzyyfoxx.me,https://*.owt.craazzzyyfoxx.me`
+
+- [ ] **Step 2: Write the ops runbook** (external, cannot be done from the repo)
+
+Document, with exact records:
+1. **DNS:** wildcard `*.owt.craazzzyyfoxx.me` → the ingress IP (A/CNAME).
+2. **TLS (Traefik, external):** wildcard cert for `*.owt.craazzzyyfoxx.me` via DNS-01 ACME (avoids Let's Encrypt per-domain rate limits). Note the DNS provider credential requirement.
+3. **OAuth provider consoles:** register `https://owt.craazzzyyfoxx.me/auth/callback` as the (only) redirect URI for Discord, Twitch, Battle.net.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/.env.example docker-compose.production.yml backend/env/auth.env.example backend/env/common.env.example docs/superpowers/plans/2026-07-06-subdomains-ops-runbook.md
+git commit -m "chore(subdomains): canonical env + ops runbook"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 rows of the spec):**
+- Data model (subdomain + seo) → Tasks 2, 3. ✓
+- Resolver (by_host + middleware + header precedence) → Tasks 4, 5, 6, 7. ✓
+- White-label lock → Tasks 7 (scope) + 14 (UI). ✓
+- OAuth single callback + signed state + domain cookies → Tasks 9, 10, 11. ✓
+- Cookie rebrand (owt_* write, aqt_* read) → Task 8 (+ used in 11). ✓
+- Per-host SEO + sitemap/robots → Tasks 12, 13. ✓
+- WS origin `*.owt` → Task 16. ✓
+- Admin editor → Task 15. ✓
+- Ops (DNS/TLS/provider registration) → Task 17. ✓
+- (Phase 2 — custom domains, SSO ticket, on-demand TLS, dynamic WS validation — intentionally excluded; separate plan.)
+
+**Placeholder scan:** No TBD/TODO; integration-only steps (middleware, cookie-domain in a real browser) use explicit `curl`/manual verification because they aren't unit-testable — that is a deliberate verification method, not a placeholder.
+
+**Type consistency:** `resolveHost`/`HostResolution` (Task 5) reused in Tasks 6, 11. `x-owt-workspace-id` / `x-owt-host-mode` headers set in Task 6, read in Tasks 7, 12, 14. State payload fields `{origin, redirect, action, provider}` produced in Task 9, consumed in Tasks 10, 11. Cookie names `owt_access_token`/`owt_refresh_token`/`owt-workspace-id` consistent across Tasks 8, 11.

--- a/docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md
+++ b/docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md
@@ -1,0 +1,143 @@
+# Workspace multi-domain (subdomains + custom domains) — design
+
+- **Date:** 2026-07-06
+- **Status:** Draft (awaiting review)
+- **Related:** per-workspace branding ([[project_workspace_branding]], `lib/workspace-theme.ts`), plan `distributed-sleeping-parrot.md`
+
+## Context & motivation
+
+Per-workspace branding (custom palette) shipped, but every workspace still lives under one shared host with the workspace chosen by a cookie (`owt-workspace-id`). Organisers want true white-label presence: a workspace reachable at its own **subdomain** (`team-a.owt.craazzzyyfoxx.me`) and/or its own **custom domain** (`tourney.customer.com`), where the host *is* the workspace.
+
+The pressing blocker is **OAuth**: the OAuth `redirect_uri` is a single hardcoded value and providers (Discord/Twitch/Battle.net) don't allow wildcard redirect URIs, so login can't round-trip on arbitrary hosts. This spec solves OAuth plus the surrounding host-awareness (resolver, cookies, SEO, WebSockets, TLS).
+
+## Decisions (locked)
+
+1. **Scope:** design both subdomains *and* custom domains; implement phased (subdomains = Phase 1, custom domains = Phase 2).
+2. **Host↔workspace:** hard white-label lock. On a tenant host the whole site is scoped to that one workspace (host overrides cookie, switcher + "all communities" hidden). The apex `owt.craazzzyyfoxx.me` stays the multi-workspace platform.
+3. **Subdomain provisioning:** opt-in, dedicated `subdomain` column (nullable, unique, strict DNS label), independent of `slug`.
+4. **Custom domain:** opt-in `custom_domain` column + DNS verification.
+5. **SEO:** dedicated `seo_title` / `seo_description` columns (default to `name`/`description`); favicon + OG image from `icon_url`. On tenant hosts these override the platform `SITE_NAME`.
+6. **Platform zone:** `owt.craazzzyyfoxx.me` — apex is the platform; subdomains `*.owt.craazzzyyfoxx.me`; session cookies scoped `Domain=.owt.craazzzyyfoxx.me`; single OAuth callback `https://owt.craazzzyyfoxx.me/auth/callback`.
+
+## Goals / non-goals
+
+**Goals:** host→workspace resolution; white-label lock; OAuth working on any host; SSO across subdomains + cross-domain handoff for custom domains; per-host SEO with workspace branding; WS origin safety; custom-domain verification.
+
+**Non-goals (this spec):** per-workspace email/SMTP domains; per-workspace OAuth *apps* (all workspaces share the platform's provider apps); multi-region; changing the workspace RBAC model.
+
+## Architecture
+
+### A. Hosts & routing (mostly already host-agnostic)
+
+- nginx is a catch-all (`server_name _`, forwards `Host`/`X-Forwarded-Proto`, `nginx/nginx.conf:61,78,81`) and the Go gateway forwards Host untouched (`gateway/internal/proxy/proxy.go:67-69`). **No nginx/gateway routing changes needed** — any host already reaches the app.
+- **TLS = external Traefik (ops dependency, not in repo).** Needs: wildcard for `*.owt.craazzzyyfoxx.me` (DNS-01 ACME, one cert — avoids LE rate limits) and on-demand per-domain certs for custom domains (HTTP-01, issued once the customer points DNS at the ingress). This is the only piece living outside the codebase.
+
+### B. Data model — `Workspace` (`backend/shared/models/tenancy/workspace.py`)
+
+New typed columns (additive migration, e.g. `wsdomain0001`):
+
+| Column | Type | Notes |
+|---|---|---|
+| `subdomain` | `str \| None` | unique, `^[a-z0-9-]+$` (strict DNS label, no `_`), reserved-label blocklist |
+| `custom_domain` | `str \| None` | unique, lowercased FQDN |
+| `custom_domain_verified_at` | `datetime \| None` | resolver matches domain only when set (fail-closed) |
+| `custom_domain_verification_token` | `str \| None` | value for the DNS TXT record |
+| `seo_title` | `str \| None` | default → `name` |
+| `seo_description` | `str \| None` | default → `description` |
+
+Reserved subdomain labels (cannot be claimed): `www`, `api`, `auth`, `admin`, `app`, `assets`, `static`, `cdn`, `mail`, `ws`. **Canonical host** (computed, not stored): `custom_domain` if verified → else `subdomain`.`owt.craazzzyyfoxx.me` → else apex `/workspace/{slug}`.
+
+Schemas: add fields to `WorkspaceRead` + `WorkspaceUpdate` (`backend/app-service/src/schemas/workspace.py`) with validators. Update path stays the generic CRUD engine (no new RPC for writes). Frontend `Workspace` type mirrors them (`frontend/src/types/workspace.types.ts`).
+
+### C. Host → workspace resolver
+
+- **New backend RPC** `rpc.app.workspaces.by_host` (`backend/app-service/src/rpc/workspaces.py`, public + cached): given a host, returns `{workspace_id, slug}` matching `subdomain` (under the platform zone) or a **verified** `custom_domain`. Backed by new indexed lookups (reuse the `get_by_slug` pattern in `services/workspace/service.py:36`).
+- **New `frontend/src/middleware.ts`:** reads `x-forwarded-host`. Apex/`www` → platform mode (no forced workspace). Tenant host → call `by_host` (aggressively cached: small, rarely-changing map; TTL + invalidate on domain change) → inject `x-owt-workspace-id` request header via `NextResponse.rewrite`. Unknown/unverified tenant host → 404 "not configured" page (never silently fall through to the apex platform).
+- **Scope precedence:** `getServerWorkspaceId` (`frontend/src/lib/api-fetch.ts:77-85`) prefers the middleware header over the cookie (host beats cookie = white-label lock). Apex → no header → existing cookie behaviour. SSR branding seed (`app/(site)/layout.tsx:13-24`) resolves from the header on tenant hosts.
+- **White-label UI:** in tenant mode hide `WorkspaceSwitcher` and the home "communities" list; the workspace-scoped chrome stays.
+
+### D. OAuth (core) — single callback + signed state
+
+The redirect_uri problem is solved by funnelling **every** provider round-trip through one registered callback and carrying the originating host in the (already stateless-HMAC) `state`.
+
+1. **One registered `redirect_uri` per provider** = `https://owt.craazzzyyfoxx.me/auth/callback`, used for authorize *and* token exchange regardless of the tenant host the user started on. Replaces the single hardcoded `OAUTH_REDIRECT` semantics (`backend/identity-service/src/services/oauth_service.py:68/167/281`, config `core/config.py:77`) — the value becomes the fixed apex callback, no longer host-varying.
+2. **Signed-state payload** (extend `oauth_service.py:464-500`): `{origin, action(login|link), provider, post_login_redirect, nonce, exp}`, HMAC-signed with `JWT_SECRET_KEY`. **CSRF defence = the signature alone** (drop the host-only `owt_oauth_state` cookie cross-check, which is unreadable on the callback host, `frontend/src/lib/oauth-login.ts:36`, `oauth-callback.ts:47,61`). `origin` is validated against the known workspace-host set. The transient action/provider/redirect cookies are folded into the state too (no cross-host cookie reliance).
+3. **Start** (`startOAuthLogin`, `frontend/src/lib/oauth-login.ts`): records the current host as `origin` in state; clamps `post_login_redirect` to the origin host (not the single `SITE_URL`).
+4. **Callback** (`frontend/src/app/(site)/auth/callback/route.ts`, `lib/oauth-callback.ts`): validate signed state (HMAC + exp + nonce + origin allow-list), exchange code, mint access+refresh JWTs (unchanged — JWTs are already host-agnostic, `gateway/internal/auth/auth.go:61-85`), then deliver the session to `origin`:
+   - **Subdomain / apex origin** → set `owt_access_token` / `owt_refresh_token` with **`Domain=.owt.craazzzyyfoxx.me`** → immediately valid on the origin subdomain (SSO across all subdomains). Redirect to `https://{origin}{post_login_redirect}`.
+   - **Custom-domain origin** → cookies can't cross registrable domains → **one-time SSO ticket**: identity-svc mints an opaque code in Redis (TTL ~60s, single-use), redirect to `https://{custom}/auth/sso?ticket=...`.
+5. **SSO handoff endpoint** (new `frontend/src/app/(site)/auth/sso/route.ts`, Phase 2): reads `ticket`, calls new `rpc.identity.sso_exchange` (redeems the one-time code server-side → returns the token pair), sets **host** cookies on the custom domain, redirects to the destination. Refresh token never appears in a URL.
+
+### E. Session / cookie strategy
+
+- **Cookie naming (aqt→owt rebrand, back-compat):** cookies are written under the new `owt_*` names (`owt_access_token`, `owt_refresh_token`, `owt-workspace-id`, `owt_oauth_*`) but **read as `owt_* ?? aqt_*`** during migration, so existing `aqt_*` sessions are not logged out. Every read site gets the fallback; every write site uses `owt_*` only. The `aqt_*` fallback is removed in a later cleanup. Read/write sites: gateway `internal/auth/auth.go:21` (name constant + read order), `frontend/src/lib/{oauth-callback,auth-tokens}.ts`, `auth/refresh/route.ts`, `stores/workspace.store.ts`, and `api-fetch.ts:77-85`.
+- Subdomains + apex: `Domain=.owt.craazzzyyfoxx.me` on `owt_access_token` (js-readable), `owt_refresh_token` (httpOnly), `owt-workspace-id`. Set in `frontend/src/lib/oauth-callback.ts:87-101`, `auth/refresh/route.ts:26-40`, `lib/auth-tokens.ts:46-51`, `stores/workspace.store.ts:71`.
+- Custom domains: host-only cookies on that domain, established via the SSO handoff (E.4/D.5). Each custom domain is an independent session island.
+- **Logout:** on subdomains/apex, clear the `.owt.craazzzyyfoxx.me` cookies → **global logout across all subdomains** (accepted). On a custom domain, clear that host's cookies only (`frontend/src/app/(site)/auth/logout/route.ts`).
+- **Account linking from a custom domain** (Phase 2 nuance): the callback can't read the custom-domain auth cookie to know who is linking → carry a short-lived signed "link intent" (user id) in the state.
+
+### F. Custom-domain verification (Phase 2)
+
+1. Organiser enters `custom_domain` in settings → stored unverified + `custom_domain_verification_token` generated.
+2. UI shows: TXT `_anak-verify.<domain> = <token>` and CNAME/A `<domain> → owt.craazzzyyfoxx.me`.
+3. "Verify" → backend DNS TXT lookup → set `custom_domain_verified_at`. Resolver only serves verified domains.
+4. TLS issued on-demand by external Traefik once DNS points at the ingress.
+
+### G. SEO / per-host metadata
+
+- Replace static `SITE_NAME`/`SITE_URL`/hardcoded `metadataBase` with **per-request, per-workspace** metadata. Root `layout.tsx` (`:35-50`) and section layouts (`app/(site)/{owal,statistics,encounters,matches,teams,tournaments,tournaments/analytics}/layout.tsx:8`, plus `users/*`) switch static `metadata` → async `generateMetadata` that resolves the host's workspace (via the middleware header + a cached fetch).
+- On tenant hosts: `title`/OG `siteName` = `seo_title ?? name`; `description` = `seo_description ?? description`; `icons.icon` (favicon) + OG image = `icon_url` (fallback to platform `/favicon.ico`, `/logo.webp`); `metadataBase`/canonical = the tenant host origin (host helper modelled on `getServerRequestOrigin`, `api-fetch.ts:87-109`).
+- `sitemap.ts` / `robots.ts` become host-scoped (emit only the current host / that workspace's URLs). Apex keeps platform-wide defaults.
+
+### H. WebSockets
+
+`GATEWAY_WS_ALLOWED_ORIGINS` (static CSV, `gateway/internal/config/config.go:130`, enforced `gateway/internal/ws/handler.go:47-58`) can't enumerate custom domains. Change the WS origin check to **dynamic validation**: allow the `*.owt.craazzzyyfoxx.me` pattern (subdomains) + validate other origins against the known workspace-host set (same lookup as the resolver). Never fall back to `InsecureSkipVerify`.
+
+## Phasing
+
+**Phase 1 — Subdomains**
+- `subdomain` + `seo_*` columns + migration; schema + type updates; admin/settings editor (toggle + field + reserved-label validation).
+- `by_host` RPC (subdomain match) + `frontend/src/middleware.ts` + header-based scope precedence + white-label UI gating.
+- OAuth: single apex callback + signed-state (origin/action/provider/redirect in state, drop state-cookie cross-check) + `Domain=.owt.craazzzyyfoxx.me` cookies.
+- Per-host SEO (workspace-branded metadata) + host-aware sitemap/robots.
+- WS origin `*.owt.craazzzyyfoxx.me`.
+- Ops: wildcard DNS `*.owt.craazzzyyfoxx.me` + wildcard TLS (DNS-01) in Traefik.
+
+**Phase 2 — Custom domains**
+- `custom_domain` + verification columns; verification flow (TXT/CNAME + DNS check) + settings UI.
+- On-demand per-domain TLS (Traefik).
+- SSO ticket handoff: `rpc.identity.sso_exchange` (Redis one-time code) + `auth/sso` route + host-cookie set on custom domain.
+- Dynamic WS origin validation for custom domains.
+- Resolver matches verified `custom_domain`; custom-domain account-linking via signed link-intent.
+
+## Security considerations
+
+- Signed-state CSRF: HMAC over `{origin, nonce, exp}` is unforgeable and is the standard stateless-CSRF pattern; short `exp` + single-use `nonce` (Redis) prevent replay. `origin` validated against the workspace-host allow-list (no open redirect).
+- SSO ticket: opaque, single-use, ~60s TTL, deleted on redemption, exchanged server-side (never carries the refresh token in a URL).
+- `owt_access_token` stays js-readable but with `Domain=.owt.craazzzyyfoxx.me` is exposed only to our own subdomains (trust boundary); custom domains get isolated host cookies.
+- Reserved-label + verified-only custom-domain matching prevent host takeover / squatting.
+
+## Edge cases
+
+- Unknown/unverified tenant host → 404 "not configured" page (no fall-through to apex).
+- Anonymous session on a custom domain → must log in there (no cross-domain cookie) → handled by ticket handoff on next login.
+- `subdomain`/`custom_domain` changed → invalidate resolver cache; old host 404s.
+- Slug change no longer affects the URL (subdomain is a separate column).
+- Apex + `www` always platform mode.
+
+## Testing
+
+- **Unit:** host→workspace resolver (subdomain/custom/apex/unknown/reserved); signed-state encode/decode (origin+action+exp+nonce, tamper rejection, origin allow-list); SSO ticket (single-use + expiry); host-origin + per-workspace metadata helpers; reserved-label + DNS-label validators.
+- **Integration:** `by_host` RPC; OAuth callback cookie-domain selection (subdomain vs custom); `sso_exchange` redemption.
+- **E2E/manual:** login on a subdomain (SSO carries across subdomains); login on a custom domain (ticket handoff sets host cookies); white-label lock (no switcher / no communities); per-host canonical + workspace-branded title/favicon; WS connect from a tenant host; unknown host → apex.
+
+## External dependencies / open items
+
+- **Traefik (ops):** wildcard DNS + wildcard TLS for `*.owt.craazzzyyfoxx.me`; on-demand per-domain ACME for custom domains. Config lives outside this repo — needs ops access.
+- **OAuth provider consoles:** register the single `https://owt.craazzzyyfoxx.me/auth/callback` redirect URI for Discord/Twitch/Battle.net.
+
+## Key affected files
+
+- Backend: `shared/models/tenancy/workspace.py`, `app-service/src/schemas/workspace.py`, `app-service/src/rpc/workspaces.py`, `app-service/src/services/workspace/service.py`, `identity-service/src/services/oauth_service.py`, `identity-service/src/core/config.py`, new migration.
+- Frontend: new `middleware.ts`, `lib/api-fetch.ts`, `lib/oauth-login.ts`, `lib/oauth-callback.ts`, `app/(site)/auth/{callback,logout,sso}/route.ts`, `config/site.ts`, root + section `layout.tsx` (generateMetadata), `sitemap.ts`, `robots.ts`, `components/WorkspaceSwitcher.tsx` + home communities, admin/settings workspace editor, `types/workspace.types.ts`.
+- Gateway: `internal/ws/handler.go`, `internal/config/config.go`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,11 +2,11 @@
 # Copy to .env (or .env.local) and restart `npm run dev`.
 
 # Site display name (title, footer, etc.)
-NEXT_PUBLIC_SITE_NAME="Moonrise Tournaments"
+NEXT_PUBLIC_SITE_NAME="Overwatch Tournaments"
 
 # Public base URL for the frontend (used in metadata like Open Graph).
 # Must be an absolute URL including protocol, e.g. "https://example.com".
-NEXT_PUBLIC_SITE_URL="https://aqt.craazzzyyfoxx.me"
+NEXT_PUBLIC_SITE_URL="https://owt.craazzzyyfoxx.me"
 
 # Main icon / logo path (must exist under `frontend/public`).
 NEXT_PUBLIC_SITE_ICON="/logo.webp"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,7 +28,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 The site name and main icon/logo are configurable via environment variables.
 
 - Copy `frontend/.env.example` to `frontend/.env` (or `frontend/.env.local`)
-- Set `NEXT_PUBLIC_SITE_NAME` (e.g. "Moonrise Tournaments")
+- Set `NEXT_PUBLIC_SITE_NAME` (e.g. "Overwatch Tournaments")
 - Set `NEXT_PUBLIC_SITE_ICON` (e.g. "/logo.webp")
 - (Optional) Set `NEXT_PUBLIC_SITE_FAVICON` (e.g. "/favicon.ico")
 - For a host-run dev server, set `NEXT_INTERNAL_API_URL` to the gateway

--- a/frontend/src/app/(site)/(home)/page.tsx
+++ b/frontend/src/app/(site)/(home)/page.tsx
@@ -45,7 +45,7 @@ export default async function Home() {
   return (
     <div className="space-y-8">
       {/* Cinematic page intro */}
-      <PageIntroSection />
+      <PageIntroSection tenantMode={tenantMode} />
 
       {/* Live / upcoming events */}
       <section>
@@ -126,7 +126,7 @@ export default async function Home() {
 // Page intro (cinematic header)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function PageIntroSection() {
+function PageIntroSection({ tenantMode }: { tenantMode: boolean }) {
   return (
     <div
       className="relative overflow-hidden rounded-xl border border-white/[0.07] p-8 md:p-10"
@@ -202,8 +202,9 @@ function PageIntroSection() {
             <span style={{ color: "hsl(162 72% 50%)" }}>now</span>
           </h1>
           <p className="text-sm leading-relaxed" style={{ color: "hsl(215 12% 52%)", maxWidth: "26rem" }}>
-            Tournaments, player stats and rankings across all communities on the
-            platform.
+            {tenantMode
+              ? "Tournaments, player stats and rankings for this community."
+              : "Tournaments, player stats and rankings across all communities on the platform."}
           </p>
         </div>
 

--- a/frontend/src/app/(site)/(home)/page.tsx
+++ b/frontend/src/app/(site)/(home)/page.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from "react";
 import Link from "next/link";
+import { headers } from "next/headers";
 import { Award, BarChart3, Calendar, Scale, Trophy, Users } from "lucide-react";
 
 import StatisticsCard from "@/components/StatisticsCard";
@@ -35,7 +36,12 @@ const HEX_GRID_BG = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/200
 // Root page
 // ─────────────────────────────────────────────────────────────────────────────
 
-export default function Home() {
+export default async function Home() {
+  // On a tenant (white-label) host the whole site is locked to one
+  // workspace, so the cross-workspace "communities on this platform" list
+  // is hidden. See middleware.ts (Task 6) for the header injection.
+  const tenantMode = (await headers()).get("x-owt-host-mode") === "tenant";
+
   return (
     <div className="space-y-8">
       {/* Cinematic page intro */}
@@ -59,17 +65,19 @@ export default function Home() {
       </section>
 
       {/* Workspace / community cards */}
-      <section>
-        <p className="mb-1.5 text-[11px] font-semibold tracking-[0.14em] uppercase text-muted-foreground/50">
-          Workspaces
-        </p>
-        <h2 className="font-display text-3xl font-bold uppercase tracking-wide text-foreground mb-5">
-          Communities on this platform
-        </h2>
-        <Suspense fallback={<CommunitiesSkeleton />}>
-          <CommunitiesSection />
-        </Suspense>
-      </section>
+      {!tenantMode && (
+        <section>
+          <p className="mb-1.5 text-[11px] font-semibold tracking-[0.14em] uppercase text-muted-foreground/50">
+            Workspaces
+          </p>
+          <h2 className="font-display text-3xl font-bold uppercase tracking-wide text-foreground mb-5">
+            Communities on this platform
+          </h2>
+          <Suspense fallback={<CommunitiesSkeleton />}>
+            <CommunitiesSection />
+          </Suspense>
+        </section>
+      )}
 
       {/* Season dashboard */}
       <section className="pb-8 space-y-4">

--- a/frontend/src/app/(site)/auth/callback/route.ts
+++ b/frontend/src/app/(site)/auth/callback/route.ts
@@ -1,25 +1,9 @@
-import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { handleOAuthCallback } from "@/lib/oauth-callback";
-import type { OAuthProviderName } from "@/types/auth.types";
 
-const ALLOWED_PROVIDERS = new Set<OAuthProviderName>(["discord", "twitch", "battlenet"]);
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-
+// Single fixed apex callback for every OAuth provider (one registered
+// redirect_uri, per docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md).
+// The provider is no longer known from a cookie or the URL — oauth-callback.ts
+// decodes it from the signed `state` query param instead (Task 9 embeds it).
 export async function GET(request: Request) {
-  const cookieStore = await cookies();
-  const provider = cookieStore.get("aqt_oauth_provider")?.value;
-
-  if (!provider || !ALLOWED_PROVIDERS.has(provider as OAuthProviderName)) {
-    const errorUrl = new URL("/", SITE_URL);
-    errorUrl.searchParams.set("auth_error", "invalid_provider");
-    const response = NextResponse.redirect(errorUrl);
-    response.cookies.delete("aqt_oauth_provider");
-    response.cookies.delete("aqt_oauth_state");
-    response.cookies.delete("aqt_post_login_redirect");
-    response.cookies.delete("aqt_oauth_action");
-    return response;
-  }
-
-  return handleOAuthCallback(request, provider as OAuthProviderName);
+  return handleOAuthCallback(request);
 }

--- a/frontend/src/app/(site)/auth/logout/route.ts
+++ b/frontend/src/app/(site)/auth/logout/route.ts
@@ -10,8 +10,9 @@ export async function GET(request: Request) {
   const nextParam = url.searchParams.get("next");
 
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
-  const refreshToken = cookieStore.get("aqt_refresh_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const refreshToken =
+    cookieStore.get("owt_refresh_token")?.value ?? cookieStore.get("aqt_refresh_token")?.value;
 
   // Best-effort server-side logout (revoke refresh token)
   try {
@@ -41,6 +42,8 @@ export async function GET(request: Request) {
   // Build redirect URL using SITE_URL to avoid 0.0.0.0 issues
   const redirectUrl = new URL(safeNext, SITE_URL);
   const response = NextResponse.redirect(redirectUrl);
+  response.cookies.delete("owt_access_token");
+  response.cookies.delete("owt_refresh_token");
   response.cookies.delete("aqt_access_token");
   response.cookies.delete("aqt_refresh_token");
   return response;

--- a/frontend/src/app/(site)/auth/logout/route.ts
+++ b/frontend/src/app/(site)/auth/logout/route.ts
@@ -2,34 +2,17 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { authService } from "@/services/auth.service";
-import { PLATFORM_ZONE } from "@/lib/host";
+import { clearAuthCookies, getAccessToken, getRefreshToken } from "@/lib/auth-cookies";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-
-const IS_PROD = process.env.NODE_ENV === "production";
-// owt_access_token/owt_refresh_token are Domain-wide cookies in production
-// (oauth-callback.ts) — a delete without the same Domain attribute creates a
-// second, host-only cookie of the same name instead of clearing the real one
-// (RFC 6265 keys a cookie by name+domain+path), which would leave the user
-// silently still logged in on every subdomain after "logging out."
-const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
-
-function deleteOwtCookie(response: NextResponse, name: string): void {
-  response.cookies.delete({
-    name,
-    path: "/",
-    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
-  });
-}
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const nextParam = url.searchParams.get("next");
 
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
-  const refreshToken =
-    cookieStore.get("owt_refresh_token")?.value ?? cookieStore.get("aqt_refresh_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
+  const refreshToken = getRefreshToken(cookieStore);
 
   // Best-effort server-side logout (revoke refresh token)
   try {
@@ -59,9 +42,6 @@ export async function GET(request: Request) {
   // Build redirect URL using SITE_URL to avoid 0.0.0.0 issues
   const redirectUrl = new URL(safeNext, SITE_URL);
   const response = NextResponse.redirect(redirectUrl);
-  deleteOwtCookie(response, "owt_access_token");
-  deleteOwtCookie(response, "owt_refresh_token");
-  response.cookies.delete("aqt_access_token");
-  response.cookies.delete("aqt_refresh_token");
+  clearAuthCookies(response);
   return response;
 }

--- a/frontend/src/app/(site)/auth/logout/route.ts
+++ b/frontend/src/app/(site)/auth/logout/route.ts
@@ -2,8 +2,25 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { authService } from "@/services/auth.service";
+import { PLATFORM_ZONE } from "@/lib/host";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
+const IS_PROD = process.env.NODE_ENV === "production";
+// owt_access_token/owt_refresh_token are Domain-wide cookies in production
+// (oauth-callback.ts) — a delete without the same Domain attribute creates a
+// second, host-only cookie of the same name instead of clearing the real one
+// (RFC 6265 keys a cookie by name+domain+path), which would leave the user
+// silently still logged in on every subdomain after "logging out."
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
+
+function deleteOwtCookie(response: NextResponse, name: string): void {
+  response.cookies.delete({
+    name,
+    path: "/",
+    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
+  });
+}
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -42,8 +59,8 @@ export async function GET(request: Request) {
   // Build redirect URL using SITE_URL to avoid 0.0.0.0 issues
   const redirectUrl = new URL(safeNext, SITE_URL);
   const response = NextResponse.redirect(redirectUrl);
-  response.cookies.delete("owt_access_token");
-  response.cookies.delete("owt_refresh_token");
+  deleteOwtCookie(response, "owt_access_token");
+  deleteOwtCookie(response, "owt_refresh_token");
   response.cookies.delete("aqt_access_token");
   response.cookies.delete("aqt_refresh_token");
   return response;

--- a/frontend/src/app/(site)/auth/refresh/route.ts
+++ b/frontend/src/app/(site)/auth/refresh/route.ts
@@ -4,38 +4,27 @@ import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { getTokenMaxAgeSeconds } from "@/lib/jwt";
 import { authService } from "@/services/auth.service";
 import { PLATFORM_ZONE } from "@/lib/host";
+import { clearAuthCookies, getRefreshToken } from "@/lib/auth-cookies";
 
 // Cookie lifetime used when the access token's `exp` can't be decoded.
 const FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS = 13 * 60;
 
 const IS_PROD = process.env.NODE_ENV === "production";
 // owt_access_token/owt_refresh_token are set Domain-wide (SSO across
-// subdomains) by oauth-callback.ts. A set/delete here without the same
-// Domain attribute doesn't overwrite that cookie — RFC 6265 keys a cookie by
+// subdomains) by oauth-callback.ts. A set here without the same Domain
+// attribute doesn't overwrite that cookie — RFC 6265 keys a cookie by
 // (name, domain, path), so a host-only Set-Cookie would create a *second*,
-// competing cookie of the same name instead of refreshing/clearing the real
-// one. Must match exactly.
+// competing cookie of the same name instead of refreshing the real one.
+// Must match exactly.
 const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
-
-function deleteOwtCookie(response: NextResponse, name: string): void {
-  response.cookies.delete({
-    name,
-    path: "/",
-    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
-  });
-}
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
-  const refreshToken =
-    cookieStore.get("owt_refresh_token")?.value ?? cookieStore.get("aqt_refresh_token")?.value;
+  const refreshToken = getRefreshToken(cookieStore);
 
   if (!refreshToken) {
     const response = NextResponse.json({ message: "Missing refresh token" }, { status: 401 });
-    deleteOwtCookie(response, "owt_access_token");
-    deleteOwtCookie(response, "owt_refresh_token");
-    response.cookies.delete("aqt_access_token");
-    response.cookies.delete("aqt_refresh_token");
+    clearAuthCookies(response);
     return response;
   }
 
@@ -65,10 +54,7 @@ export async function POST(request: Request) {
     return response;
   } catch {
     const response = NextResponse.json({ message: "Failed to refresh" }, { status: 401 });
-    deleteOwtCookie(response, "owt_access_token");
-    deleteOwtCookie(response, "owt_refresh_token");
-    response.cookies.delete("aqt_access_token");
-    response.cookies.delete("aqt_refresh_token");
+    clearAuthCookies(response);
     return response;
   }
 }

--- a/frontend/src/app/(site)/auth/refresh/route.ts
+++ b/frontend/src/app/(site)/auth/refresh/route.ts
@@ -3,9 +3,27 @@ import { cookies } from "next/headers";
 import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { getTokenMaxAgeSeconds } from "@/lib/jwt";
 import { authService } from "@/services/auth.service";
+import { PLATFORM_ZONE } from "@/lib/host";
 
 // Cookie lifetime used when the access token's `exp` can't be decoded.
 const FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS = 13 * 60;
+
+const IS_PROD = process.env.NODE_ENV === "production";
+// owt_access_token/owt_refresh_token are set Domain-wide (SSO across
+// subdomains) by oauth-callback.ts. A set/delete here without the same
+// Domain attribute doesn't overwrite that cookie — RFC 6265 keys a cookie by
+// (name, domain, path), so a host-only Set-Cookie would create a *second*,
+// competing cookie of the same name instead of refreshing/clearing the real
+// one. Must match exactly.
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
+
+function deleteOwtCookie(response: NextResponse, name: string): void {
+  response.cookies.delete({
+    name,
+    path: "/",
+    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
+  });
+}
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
@@ -14,8 +32,8 @@ export async function POST(request: Request) {
 
   if (!refreshToken) {
     const response = NextResponse.json({ message: "Missing refresh token" }, { status: 401 });
-    response.cookies.delete("owt_access_token");
-    response.cookies.delete("owt_refresh_token");
+    deleteOwtCookie(response, "owt_access_token");
+    deleteOwtCookie(response, "owt_refresh_token");
     response.cookies.delete("aqt_access_token");
     response.cookies.delete("aqt_refresh_token");
     return response;
@@ -29,24 +47,26 @@ export async function POST(request: Request) {
     response.cookies.set("owt_access_token", tokens.access_token, {
       httpOnly: false,
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      secure: IS_PROD,
       path: "/",
-      maxAge: getTokenMaxAgeSeconds(tokens.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS)
+      maxAge: getTokenMaxAgeSeconds(tokens.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS),
+      ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
     });
 
     response.cookies.set("owt_refresh_token", tokens.refresh_token, {
       httpOnly: true,
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      secure: IS_PROD,
       path: "/",
-      maxAge: 30 * 24 * 60 * 60
+      maxAge: 30 * 24 * 60 * 60,
+      ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
     });
 
     return response;
   } catch {
     const response = NextResponse.json({ message: "Failed to refresh" }, { status: 401 });
-    response.cookies.delete("owt_access_token");
-    response.cookies.delete("owt_refresh_token");
+    deleteOwtCookie(response, "owt_access_token");
+    deleteOwtCookie(response, "owt_refresh_token");
     response.cookies.delete("aqt_access_token");
     response.cookies.delete("aqt_refresh_token");
     return response;

--- a/frontend/src/app/(site)/auth/refresh/route.ts
+++ b/frontend/src/app/(site)/auth/refresh/route.ts
@@ -9,10 +9,13 @@ const FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS = 13 * 60;
 
 export async function POST(request: Request) {
   const cookieStore = await cookies();
-  const refreshToken = cookieStore.get("aqt_refresh_token")?.value;
+  const refreshToken =
+    cookieStore.get("owt_refresh_token")?.value ?? cookieStore.get("aqt_refresh_token")?.value;
 
   if (!refreshToken) {
     const response = NextResponse.json({ message: "Missing refresh token" }, { status: 401 });
+    response.cookies.delete("owt_access_token");
+    response.cookies.delete("owt_refresh_token");
     response.cookies.delete("aqt_access_token");
     response.cookies.delete("aqt_refresh_token");
     return response;
@@ -23,7 +26,7 @@ export async function POST(request: Request) {
 
     const response = NextResponse.json(tokens, { status: 200 });
 
-    response.cookies.set("aqt_access_token", tokens.access_token, {
+    response.cookies.set("owt_access_token", tokens.access_token, {
       httpOnly: false,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",
@@ -31,7 +34,7 @@ export async function POST(request: Request) {
       maxAge: getTokenMaxAgeSeconds(tokens.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS)
     });
 
-    response.cookies.set("aqt_refresh_token", tokens.refresh_token, {
+    response.cookies.set("owt_refresh_token", tokens.refresh_token, {
       httpOnly: true,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",
@@ -42,6 +45,8 @@ export async function POST(request: Request) {
     return response;
   } catch {
     const response = NextResponse.json({ message: "Failed to refresh" }, { status: 401 });
+    response.cookies.delete("owt_access_token");
+    response.cookies.delete("owt_refresh_token");
     response.cookies.delete("aqt_access_token");
     response.cookies.delete("aqt_refresh_token");
     return response;

--- a/frontend/src/app/(site)/encounters/layout.tsx
+++ b/frontend/src/app/(site)/encounters/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Encounters | ${SITE_NAME}`,
-  description: `View encounters on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Encounters | ${SITE_NAME}`,
-    description: `View encounters on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Encounters | ${SITE_NAME}`;
+  const description = `View encounters on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import Header from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Separator } from "@/components/ui/separator";
@@ -34,11 +34,17 @@ export default async function SiteLayout({
     ? ({ ...seed, backgroundColor: "var(--aqt-bg)" } as React.CSSProperties)
     : undefined;
 
+  // On a tenant (white-label) host, `middleware.ts` (Task 6) injects
+  // `x-owt-host-mode: tenant` — the whole site is locked to one workspace,
+  // so cross-workspace UI (the workspace switcher, the communities list)
+  // must be hidden. Absent on the apex/platform host.
+  const tenantMode = (await headers()).get("x-owt-host-mode") === "tenant";
+
   return (
     <div className="site-theme min-h-screen w-full" style={style}>
       <WorkspaceThemeSync />
       <div className="w-full max-w-screen-3xl mt-6 mx-auto px-4 md:px-6 xl:px-10 h-full">
-        <Header />
+        <Header tenantMode={tenantMode} />
         <div className="flex w-full flex-col min-h-[95%]">
           <main className="flex flex-1 flex-col gap-4 pt-4 md:gap-8 md:pt-8">
             {children}

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -8,12 +8,13 @@ import { deriveWorkspacePalette, type CssVarMap } from "@/lib/workspace-theme";
 import { WorkspaceThemeSync } from "@/components/WorkspaceThemeSync";
 
 // Resolve the current workspace's branding server-side (from the same
-// `aqt-workspace-id` cookie the API scoping uses) so the first paint is already
-// themed — no flash. Failures degrade to the default palette.
+// `owt-workspace-id` cookie — legacy `aqt-workspace-id` as a fallback — the
+// API scoping uses) so the first paint is already themed — no flash. Failures
+// degrade to the default palette.
 async function resolveSeedPalette(): Promise<CssVarMap | null> {
   try {
     const cookieStore = await cookies();
-    const raw = cookieStore.get("aqt-workspace-id")?.value;
+    const raw = cookieStore.get("owt-workspace-id")?.value ?? cookieStore.get("aqt-workspace-id")?.value;
     const id = raw ? Number(raw) : NaN;
     if (!Number.isFinite(id)) return null;
     const workspace = await workspaceService.getById(id);

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -1,23 +1,51 @@
 import React from "react";
+import { cookies } from "next/headers";
 import Header from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Separator } from "@/components/ui/separator";
+import workspaceService from "@/services/workspace.service";
+import { deriveWorkspacePalette, type CssVarMap } from "@/lib/workspace-theme";
+import { WorkspaceThemeSync } from "@/components/WorkspaceThemeSync";
 
-export default function SiteLayout({
+// Resolve the current workspace's branding server-side (from the same
+// `aqt-workspace-id` cookie the API scoping uses) so the first paint is already
+// themed — no flash. Failures degrade to the default palette.
+async function resolveSeedPalette(): Promise<CssVarMap | null> {
+  try {
+    const cookieStore = await cookies();
+    const raw = cookieStore.get("aqt-workspace-id")?.value;
+    const id = raw ? Number(raw) : NaN;
+    if (!Number.isFinite(id)) return null;
+    const workspace = await workspaceService.getById(id);
+    return deriveWorkspacePalette(workspace);
+  } catch {
+    return null;
+  }
+}
+
+export default async function SiteLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const seed = await resolveSeedPalette();
+  const style: React.CSSProperties | undefined = seed
+    ? ({ ...seed, backgroundColor: "var(--aqt-bg)" } as React.CSSProperties)
+    : undefined;
+
   return (
-    <div className="w-full max-w-screen-3xl mt-6 mx-auto px-4 md:px-6 xl:px-10 h-full">
-      <Header />
-      <div className="flex w-full flex-col min-h-[95%]">
-        <main className="flex flex-1 flex-col gap-4 pt-4 md:gap-8 md:pt-8">
-          {children}
-        </main>
+    <div className="site-theme min-h-screen w-full" style={style}>
+      <WorkspaceThemeSync />
+      <div className="w-full max-w-screen-3xl mt-6 mx-auto px-4 md:px-6 xl:px-10 h-full">
+        <Header />
+        <div className="flex w-full flex-col min-h-[95%]">
+          <main className="flex flex-1 flex-col gap-4 pt-4 md:gap-8 md:pt-8">
+            {children}
+          </main>
+        </div>
+        <Separator className="mt-8" />
+        <Footer />
       </div>
-      <Separator className="mt-8" />
-      <Footer />
     </div>
   );
 }

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import workspaceService from "@/services/workspace.service";
 import { deriveWorkspacePalette } from "@/lib/workspace-theme";
 import { WorkspaceThemeSync } from "@/components/WorkspaceThemeSync";
+import { WorkspaceHostLock } from "@/components/WorkspaceHostLock";
 import type { Workspace } from "@/types/workspace.types";
 
 // Resolve the current workspace server-side. On a tenant (white-label) host
@@ -53,6 +54,7 @@ export default async function SiteLayout({
 
   return (
     <div className="site-theme min-h-screen w-full" style={style}>
+      <WorkspaceHostLock workspaceId={tenantMode && workspace ? workspace.id : null} />
       <WorkspaceThemeSync />
       <div className="w-full max-w-screen-3xl mt-6 mx-auto px-4 md:px-6 xl:px-10 h-full">
         <Header tenantMode={tenantMode} tenantWorkspace={tenantWorkspace} />

--- a/frontend/src/app/(site)/layout.tsx
+++ b/frontend/src/app/(site)/layout.tsx
@@ -4,21 +4,26 @@ import Header from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { Separator } from "@/components/ui/separator";
 import workspaceService from "@/services/workspace.service";
-import { deriveWorkspacePalette, type CssVarMap } from "@/lib/workspace-theme";
+import { deriveWorkspacePalette } from "@/lib/workspace-theme";
 import { WorkspaceThemeSync } from "@/components/WorkspaceThemeSync";
+import type { Workspace } from "@/types/workspace.types";
 
-// Resolve the current workspace's branding server-side (from the same
-// `owt-workspace-id` cookie — legacy `aqt-workspace-id` as a fallback — the
-// API scoping uses) so the first paint is already themed — no flash. Failures
-// degrade to the default palette.
-async function resolveSeedPalette(): Promise<CssVarMap | null> {
+// Resolve the current workspace server-side. On a tenant (white-label) host
+// `middleware.ts` (Task 6) injects `x-owt-workspace-id` — authoritative, host
+// beats cookie — so the palette seed and the tenant header logo both follow the
+// host, not a stale cookie. On the apex we fall back to the workspace cookie
+// (legacy `aqt-` as a second fallback). Failures degrade to null.
+async function resolveCurrentWorkspace(): Promise<Workspace | null> {
   try {
+    const h = await headers();
     const cookieStore = await cookies();
-    const raw = cookieStore.get("owt-workspace-id")?.value ?? cookieStore.get("aqt-workspace-id")?.value;
+    const raw =
+      h.get("x-owt-workspace-id") ??
+      cookieStore.get("owt-workspace-id")?.value ??
+      cookieStore.get("aqt-workspace-id")?.value;
     const id = raw ? Number(raw) : NaN;
     if (!Number.isFinite(id)) return null;
-    const workspace = await workspaceService.getById(id);
-    return deriveWorkspacePalette(workspace);
+    return await workspaceService.getById(id);
   } catch {
     return null;
   }
@@ -29,22 +34,28 @@ export default async function SiteLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const seed = await resolveSeedPalette();
+  const tenantMode = (await headers()).get("x-owt-host-mode") === "tenant";
+  const workspace = await resolveCurrentWorkspace();
+
+  // Branding seed for a flash-free first paint (no-op when the workspace has no
+  // custom palette).
+  const seed = workspace ? deriveWorkspacePalette(workspace) : null;
   const style: React.CSSProperties | undefined = seed
     ? ({ ...seed, backgroundColor: "var(--aqt-bg)" } as React.CSSProperties)
     : undefined;
 
-  // On a tenant (white-label) host, `middleware.ts` (Task 6) injects
-  // `x-owt-host-mode: tenant` — the whole site is locked to one workspace,
-  // so cross-workspace UI (the workspace switcher, the communities list)
-  // must be hidden. Absent on the apex/platform host.
-  const tenantMode = (await headers()).get("x-owt-host-mode") === "tenant";
+  // On a tenant host the workspace switcher is replaced by the workspace's own
+  // logo (icon + name) linking home; on the apex the switcher is shown.
+  const tenantWorkspace =
+    tenantMode && workspace
+      ? { name: workspace.name, iconUrl: workspace.icon_url }
+      : undefined;
 
   return (
     <div className="site-theme min-h-screen w-full" style={style}>
       <WorkspaceThemeSync />
       <div className="w-full max-w-screen-3xl mt-6 mx-auto px-4 md:px-6 xl:px-10 h-full">
-        <Header tenantMode={tenantMode} />
+        <Header tenantMode={tenantMode} tenantWorkspace={tenantWorkspace} />
         <div className="flex w-full flex-col min-h-[95%]">
           <main className="flex flex-1 flex-col gap-4 pt-4 md:gap-8 md:pt-8">
             {children}

--- a/frontend/src/app/(site)/matches/layout.tsx
+++ b/frontend/src/app/(site)/matches/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Matches | ${SITE_NAME}`,
-  description: `View matches on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Matches | ${SITE_NAME}`,
-    description: `View matches on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Matches | ${SITE_NAME}`;
+  const description = `View matches on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/not-configured/page.tsx
+++ b/frontend/src/app/(site)/not-configured/page.tsx
@@ -1,0 +1,10 @@
+export default function NotConfigured() {
+  return (
+    <div className="mx-auto max-w-md py-24 text-center">
+      <h1 className="text-2xl font-semibold">Workspace not configured</h1>
+      <p className="mt-2 text-muted-foreground">
+        This address is not linked to a workspace yet.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/(site)/owal/layout.tsx
+++ b/frontend/src/app/(site)/owal/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `OWAL | ${SITE_NAME}`,
-  description: `View OWAL Standings on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `OWAL | ${SITE_NAME}`,
-    description: `View OWAL Standings on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `OWAL | ${SITE_NAME}`;
+  const description = `View OWAL Standings on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/statistics/layout.tsx
+++ b/frontend/src/app/(site)/statistics/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Statistics | ${SITE_NAME}`,
-  description: `View statistics on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Statistics | ${SITE_NAME}`,
-    description: `View statistics on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Statistics | ${SITE_NAME}`;
+  const description = `View statistics on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/teams/layout.tsx
+++ b/frontend/src/app/(site)/teams/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Teams | ${SITE_NAME}`,
-  description: `View teams on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Teams | ${SITE_NAME}`,
-    description: `View teams on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Teams | ${SITE_NAME}`;
+  const description = `View teams on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/tournaments/[id]/layout.tsx
+++ b/frontend/src/app/(site)/tournaments/[id]/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 
 import TournamentClientLayout from "./_components/TournamentClientLayout";
 import { getTournament } from "./_data";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
 export const dynamic = "force-dynamic";
 
@@ -11,27 +12,32 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
   const params = await props.params;
   const tournamentId = Number(params.id);
+  const { name, origin } = await resolveSiteMetadata();
+  const metadataBase = new URL(origin);
 
   try {
     const tournament = await getTournament(tournamentId);
     const title = `${tournament.name} | AQT`;
+    const description = `Overview for ${tournament.name} on AQT.`;
 
     return {
       title,
-      description: `Overview for ${tournament.name} on AQT.`,
+      description,
+      metadataBase,
       openGraph: {
         title,
-        description: `Overview for ${tournament.name} on AQT.`,
-        url: `https://aqt.craazzzyyfoxx.me/tournaments/${tournamentId}`,
+        description,
+        url: `${origin}/tournaments/${tournamentId}`,
         type: "website",
-        siteName: "AQT",
+        siteName: name,
         locale: "en_US"
       }
     };
   } catch {
     return {
       title: "Tournament | AQT",
-      description: "Tournament overview on AQT."
+      description: "Tournament overview on AQT.",
+      metadataBase
     };
   }
 }

--- a/frontend/src/app/(site)/tournaments/analytics/layout.tsx
+++ b/frontend/src/app/(site)/tournaments/analytics/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Tournaments Analytics | ${SITE_NAME}`,
-  description: `View tournaments analytics on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Tournaments Analytics | ${SITE_NAME}`,
-    description: `View tournaments analytics on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Tournaments Analytics | ${SITE_NAME}`;
+  const description = `View tournaments analytics on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/tournaments/layout.tsx
+++ b/frontend/src/app/(site)/tournaments/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
 import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Tournaments | ${SITE_NAME}`,
-  description: `View tournaments on ${SITE_NAME}.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  openGraph: {
-    title: `Tournaments | ${SITE_NAME}`,
-    description: `View tournaments on ${SITE_NAME}.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Tournaments | ${SITE_NAME}`;
+  const description = `View tournaments on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/(site)/users/layout.tsx
+++ b/frontend/src/app/(site)/users/layout.tsx
@@ -1,20 +1,26 @@
 import type { Metadata } from "next";
 import React from "react";
-import { SITE_NAME, SITE_URL, SITE_URL_OBJ } from "@/config/site";
+import { SITE_NAME } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: `Users | ${SITE_NAME}`,
-  description: `View users on ${SITE_NAME}.`,
-  metadataBase: SITE_URL_OBJ,
-  openGraph: {
-    title: `Users | ${SITE_NAME}`,
-    description: `View users on ${SITE_NAME}.`,
-    url: SITE_URL,
-    type: "website",
-    siteName: SITE_URL,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, origin } = await resolveSiteMetadata();
+  const title = `Users | ${SITE_NAME}`;
+  const description = `View users on ${SITE_NAME}.`;
+  return {
+    title,
+    description,
+    metadataBase: new URL(origin),
+    openGraph: {
+      title,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return <>{children}</>;

--- a/frontend/src/app/admin/workspaces/page.tsx
+++ b/frontend/src/app/admin/workspaces/page.tsx
@@ -19,6 +19,7 @@ import { notify } from "@/lib/notify";
 import { usePermissions } from "@/hooks/usePermissions";
 import { hasUnsavedChanges } from "@/lib/form-change";
 import { deriveWorkspacePalette } from "@/lib/workspace-theme";
+import { PLATFORM_ZONE } from "@/lib/host";
 import workspaceService from "@/services/workspace.service";
 import { Workspace } from "@/types/workspace.types";
 import { useWorkspaceStore } from "@/stores/workspace.store";
@@ -38,6 +39,9 @@ interface WorkspaceUpdateFormData {
   brand_secondary?: string | null;
   brand_background?: string | null;
   brand_surface?: string | null;
+  subdomain?: string | null;
+  seo_title?: string | null;
+  seo_description?: string | null;
 }
 
 function BrandColorField({
@@ -189,6 +193,9 @@ export default function WorkspacesPage() {
       brand_secondary: ws.brand_secondary,
       brand_background: ws.brand_background,
       brand_surface: ws.brand_surface,
+      subdomain: ws.subdomain,
+      seo_title: ws.seo_title,
+      seo_description: ws.seo_description,
     });
     setIconFile(null);
     setIconPreview(ws.icon_url || null);
@@ -559,6 +566,47 @@ export default function WorkspacesPage() {
                 clamped to a dark shade to keep text readable.
               </p>
             )}
+          </div>
+
+          {/* Domain & SEO — subdomain routing + public metadata */}
+          <div className="space-y-3 rounded-md border p-3">
+            <div>
+              <Label htmlFor="edit-subdomain">Subdomain</Label>
+              <Input
+                id="edit-subdomain"
+                value={editForm.subdomain ?? ""}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    subdomain: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "")
+                  })
+                }
+                placeholder="my-team"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                {editForm.subdomain
+                  ? `${editForm.subdomain}.${PLATFORM_ZONE}`
+                  : "Leave blank to use the platform URL only"}
+              </p>
+            </div>
+            <div>
+              <Label htmlFor="edit-seo-title">SEO title</Label>
+              <Input
+                id="edit-seo-title"
+                value={editForm.seo_title ?? ""}
+                onChange={(e) => setFormData({ ...formData, seo_title: e.target.value })}
+                placeholder="Displayed in browser tabs and search results"
+              />
+            </div>
+            <div>
+              <Label htmlFor="edit-seo-description">SEO description</Label>
+              <Input
+                id="edit-seo-description"
+                value={editForm.seo_description ?? ""}
+                onChange={(e) => setFormData({ ...formData, seo_description: e.target.value })}
+                placeholder="Optional meta description shown in search results"
+              />
+            </div>
           </div>
         </div>
       </EntityFormDialog>

--- a/frontend/src/app/admin/workspaces/page.tsx
+++ b/frontend/src/app/admin/workspaces/page.tsx
@@ -600,7 +600,7 @@ export default function WorkspacesPage() {
             </div>
             <div>
               <Label htmlFor="edit-seo-description">SEO description</Label>
-              <Input
+              <Textarea
                 id="edit-seo-description"
                 value={editForm.seo_description ?? ""}
                 onChange={(e) => setFormData({ ...formData, seo_description: e.target.value })}

--- a/frontend/src/app/admin/workspaces/page.tsx
+++ b/frontend/src/app/admin/workspaces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
 import { Plus, Pencil, Trash2, CheckCircle, XCircle } from "lucide-react";
@@ -12,11 +12,13 @@ import { DeleteConfirmDialog } from "@/components/admin/DeleteConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { EditableAvatar } from "@/components/ui/editable-avatar";
 import { notify } from "@/lib/notify";
 import { usePermissions } from "@/hooks/usePermissions";
 import { hasUnsavedChanges } from "@/lib/form-change";
+import { deriveWorkspacePalette } from "@/lib/workspace-theme";
 import workspaceService from "@/services/workspace.service";
 import { Workspace } from "@/types/workspace.types";
 import { useWorkspaceStore } from "@/stores/workspace.store";
@@ -31,6 +33,47 @@ interface WorkspaceUpdateFormData {
   name?: string;
   description?: string;
   is_active?: boolean;
+  branding_enabled?: boolean;
+  brand_primary?: string | null;
+  brand_secondary?: string | null;
+  brand_background?: string | null;
+  brand_surface?: string | null;
+}
+
+function BrandColorField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string | null | undefined;
+  onChange: (value: string) => void;
+}) {
+  const hex = value ?? "";
+  const valid = /^#[0-9a-fA-F]{6}$/.test(hex);
+  return (
+    <div>
+      <Label htmlFor={id}>{label}</Label>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={`${label} color`}
+          value={valid ? hex : "#000000"}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-9 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
+        />
+        <Input
+          id={id}
+          value={hex}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="#000000"
+          className="font-mono"
+        />
+      </div>
+    </div>
+  );
 }
 
 const emptyForm: WorkspaceFormData = {
@@ -138,7 +181,15 @@ export default function WorkspacesPage() {
 
   const handleEdit = (ws: Workspace) => {
     setSelected(ws);
-    setFormData({ name: ws.name, description: ws.description || "" });
+    setFormData({
+      name: ws.name,
+      description: ws.description || "",
+      branding_enabled: ws.branding_enabled,
+      brand_primary: ws.brand_primary,
+      brand_secondary: ws.brand_secondary,
+      brand_background: ws.brand_background,
+      brand_surface: ws.brand_surface,
+    });
     setIconFile(null);
     setIconPreview(ws.icon_url || null);
     setEditOpen(true);
@@ -224,6 +275,15 @@ export default function WorkspacesPage() {
       }
     }
   ];
+
+  const editForm = formData as WorkspaceUpdateFormData;
+  const brandingPreview = deriveWorkspacePalette({
+    branding_enabled: true,
+    brand_primary: editForm.brand_primary ?? null,
+    brand_secondary: editForm.brand_secondary ?? null,
+    brand_background: editForm.brand_background ?? null,
+    brand_surface: editForm.brand_surface ?? null,
+  });
 
   return (
     <div className="flex flex-col gap-6">
@@ -407,6 +467,98 @@ export default function WorkspacesPage() {
               />
             </div>
             <p className="text-xs text-muted-foreground mt-1">PNG, JPEG, WebP or GIF, max 2 MB</p>
+          </div>
+
+          {/* Branding — applies to the main public site only */}
+          <div className="space-y-3 rounded-md border p-3">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label htmlFor="branding-enabled">Site branding</Label>
+                <p className="text-xs text-muted-foreground">
+                  Custom palette for this workspace on the main site
+                </p>
+              </div>
+              <Switch
+                id="branding-enabled"
+                checked={editForm.branding_enabled ?? false}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, branding_enabled: checked })
+                }
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <BrandColorField
+                id="brand-primary"
+                label="Primary accent"
+                value={editForm.brand_primary}
+                onChange={(v) => setFormData({ ...formData, brand_primary: v })}
+              />
+              <BrandColorField
+                id="brand-secondary"
+                label="Secondary accent"
+                value={editForm.brand_secondary}
+                onChange={(v) => setFormData({ ...formData, brand_secondary: v })}
+              />
+              <BrandColorField
+                id="brand-background"
+                label="Background"
+                value={editForm.brand_background}
+                onChange={(v) => setFormData({ ...formData, brand_background: v })}
+              />
+              <BrandColorField
+                id="brand-surface"
+                label="Surface"
+                value={editForm.brand_surface}
+                onChange={(v) => setFormData({ ...formData, brand_surface: v })}
+              />
+            </div>
+
+            {brandingPreview ? (
+              <div
+                className="rounded-md border p-3"
+                style={{ ...brandingPreview, background: "var(--aqt-bg)" } as CSSProperties}
+              >
+                <div className="text-xs font-medium" style={{ color: "var(--aqt-fg)" }}>
+                  Preview
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <span
+                    className="rounded px-2 py-1 text-xs font-medium"
+                    style={{
+                      background: "var(--aqt-teal)",
+                      color: "hsl(var(--primary-foreground))",
+                    }}
+                  >
+                    Primary
+                  </span>
+                  <span
+                    className="rounded px-2 py-1 text-xs font-medium"
+                    style={{
+                      background: "var(--aqt-violet)",
+                      color: "hsl(var(--secondary-foreground))",
+                    }}
+                  >
+                    Secondary
+                  </span>
+                  <span
+                    className="rounded px-2 py-1 text-xs"
+                    style={{
+                      background: "var(--aqt-card)",
+                      color: "var(--aqt-fg-muted)",
+                      border: "1px solid var(--aqt-border)",
+                    }}
+                  >
+                    Surface
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Set at least a primary accent and a background to preview. Backgrounds are
+                clamped to a dark shade to keep text readable.
+              </p>
+            )}
           </div>
         </div>
       </EntityFormDialog>

--- a/frontend/src/app/api/account/api-keys/[apiKeyId]/route.ts
+++ b/frontend/src/app/api/account/api-keys/[apiKeyId]/route.ts
@@ -1,6 +1,7 @@
 import { authServiceBase } from "@/lib/api-routes";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAccessToken } from "@/lib/auth-cookies";
 
 const AUTH_SERVICE_URL = authServiceBase();
 
@@ -17,7 +18,7 @@ function authHeaders(accessToken: string): HeadersInit {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
   const { apiKeyId } = await context.params;
 
   if (!accessToken) {
@@ -40,7 +41,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
   const { apiKeyId } = await context.params;
 
   if (!accessToken) {

--- a/frontend/src/app/api/account/api-keys/[apiKeyId]/route.ts
+++ b/frontend/src/app/api/account/api-keys/[apiKeyId]/route.ts
@@ -17,7 +17,7 @@ function authHeaders(accessToken: string): HeadersInit {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
   const { apiKeyId } = await context.params;
 
   if (!accessToken) {
@@ -40,7 +40,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
 export async function DELETE(_request: NextRequest, context: RouteContext) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
   const { apiKeyId } = await context.params;
 
   if (!accessToken) {

--- a/frontend/src/app/api/account/api-keys/route.ts
+++ b/frontend/src/app/api/account/api-keys/route.ts
@@ -13,7 +13,7 @@ function authHeaders(accessToken: string): HeadersInit {
 
 export async function GET(request: NextRequest) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
   const workspaceId = request.nextUrl.searchParams.get("workspace_id");
 
   if (!accessToken) {
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/account/api-keys/route.ts
+++ b/frontend/src/app/api/account/api-keys/route.ts
@@ -1,6 +1,7 @@
 import { authServiceBase } from "@/lib/api-routes";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAccessToken } from "@/lib/auth-cookies";
 
 const AUTH_SERVICE_URL = authServiceBase();
 
@@ -13,7 +14,7 @@ function authHeaders(accessToken: string): HeadersInit {
 
 export async function GET(request: NextRequest) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
   const workspaceId = request.nextUrl.searchParams.get("workspace_id");
 
   if (!accessToken) {
@@ -40,7 +41,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/account/sessions/[sessionId]/route.ts
+++ b/frontend/src/app/api/account/sessions/[sessionId]/route.ts
@@ -10,7 +10,7 @@ export async function DELETE(
 ) {
   const { sessionId } = await context.params;
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/account/sessions/[sessionId]/route.ts
+++ b/frontend/src/app/api/account/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { authServiceBase } from "@/lib/api-routes";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAccessToken } from "@/lib/auth-cookies";
 
 const AUTH_SERVICE_URL = authServiceBase();
 
@@ -10,7 +11,7 @@ export async function DELETE(
 ) {
   const { sessionId } = await context.params;
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/account/sessions/route.ts
+++ b/frontend/src/app/api/account/sessions/route.ts
@@ -6,7 +6,7 @@ const AUTH_SERVICE_URL = authServiceBase();
 
 export async function GET() {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/account/sessions/route.ts
+++ b/frontend/src/app/api/account/sessions/route.ts
@@ -1,12 +1,13 @@
 import { authServiceBase } from "@/lib/api-routes";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAccessToken } from "@/lib/auth-cookies";
 
 const AUTH_SERVICE_URL = authServiceBase();
 
 export async function GET() {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -28,7 +28,7 @@ const AUTH_SERVICE_URL = authServiceBase();
 
 export async function GET() {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("aqt_access_token")?.value;
+  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/api/auth/me/route.ts
+++ b/frontend/src/app/api/auth/me/route.ts
@@ -1,6 +1,7 @@
 import { authServiceBase } from "@/lib/api-routes";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { getAccessToken } from "@/lib/auth-cookies";
 
 export type MeResponse = {
   id: number | null;
@@ -28,7 +29,7 @@ const AUTH_SERVICE_URL = authServiceBase();
 
 export async function GET() {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+  const accessToken = getAccessToken(cookieStore);
 
   if (!accessToken) {
     return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,30 +24,33 @@ const barlowCondensed = Barlow_Condensed({
 });
 import { Providers } from "@/app/providers";
 import { GoogleAnalytics } from "@next/third-parties/google";
-import { SITE_FAVICON, SITE_NAME } from "@/config/site";
 import { cn } from "@/lib/utils";
 import AuthModal from "@/components/AuthModal";
 import AccountSettingsModal from "@/components/AccountSettingsModal";
 import LoginModalTrigger from "@/components/LoginModalTrigger";
 import { Toaster } from "@/components/ui/sonner";
 import { Suspense } from "react";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
-  title: SITE_NAME,
-  description: `${SITE_NAME} is a tool for analyzing Anak's tournaments.`,
-  metadataBase: new URL("https://aqt.craazzzyyfoxx.me"),
-  icons: {
-    icon: SITE_FAVICON
-  },
-  openGraph: {
-    title: SITE_NAME,
-    description: `${SITE_NAME} is a tool for analyzing Anak's tournaments.`,
-    url: "https://aqt.craazzzyyfoxx.me",
-    type: "website",
-    siteName: SITE_NAME,
-    locale: "en_US"
-  }
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const { name, description, origin, icon } = await resolveSiteMetadata();
+  return {
+    title: name,
+    description,
+    metadataBase: new URL(origin),
+    icons: {
+      icon
+    },
+    openGraph: {
+      title: name,
+      description,
+      url: origin,
+      type: "website",
+      siteName: name,
+      locale: "en_US"
+    }
+  };
+}
 
 export default function RootLayout({
   children

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from "next";
 import { resolveSiteMetadata } from "@/lib/site-metadata";
 
+// This route is fully dynamic (resolveSiteMetadata() reads headers() to reflect
+// the current tenant host), but that's cheap here — there's no heavy fetch like
+// the sitemap's user list, so per-request generation needs no caching.
 export default async function robots(): Promise<MetadataRoute.Robots> {
   const metadata = await resolveSiteMetadata();
   const base = metadata.origin;

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
-import { SITE_URL_OBJ } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 
-export default function robots(): MetadataRoute.Robots {
-  const base = SITE_URL_OBJ.toString().replace(/\/$/, "");
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const metadata = await resolveSiteMetadata();
+  const base = metadata.origin;
   return {
     rules: [
       {

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,44 +1,71 @@
 import type { MetadataRoute } from "next";
+import { headers } from "next/headers";
+import { unstable_cache } from "next/cache";
 import userService from "@/services/user.service";
 import { SortDirection } from "@/types/pagination.types";
 import { resolveSiteMetadata } from "@/lib/site-metadata";
 import { toUserSlug } from "@/app/(site)/users/components/users-overview/utils";
 
-// Regenerated daily. NOTE: emits up to SITE_USER_CAP player profiles in a single
-// sitemap; if the roster ever approaches 50k URLs, switch to generateSitemaps()
-// chunking (and ideally a lightweight backend /users/sitemap slug endpoint).
-export const revalidate = 86400;
+// This route is fully dynamic: `resolveSiteMetadata()` and the workspace lookup
+// below both read `headers()` so the URLs/entries reflect the current tenant
+// host on every request. The expensive part — `userService.getAll(...)`, up to
+// SITE_USER_CAP rows — is NOT re-run per request: it's wrapped in
+// `unstable_cache` keyed by workspace id and revalidated once every 24h, so the
+// backend still only sees one fetch per workspace per day. NOTE: emits up to
+// SITE_USER_CAP player profiles in a single sitemap; if the roster ever
+// approaches 50k URLs, switch to generateSitemaps() chunking (and ideally a
+// lightweight backend /users/sitemap slug endpoint).
+export const dynamic = "force-dynamic";
 
 const SITE_USER_CAP = 5000;
+
+// Must NOT call headers()/cookies() — Next.js forbids dynamic APIs inside
+// unstable_cache. The workspace id is passed in explicitly by the caller
+// instead of being resolved from ambient request state.
+async function fetchUsersForWorkspace(workspaceId: string | null): Promise<string[]> {
+  try {
+    const res = await userService.getAll(
+      {
+        page: 1,
+        per_page: SITE_USER_CAP,
+        sort: "id",
+        order: SortDirection.asc,
+        query: "",
+        fields: [],
+        entities: []
+      },
+      { workspaceId }
+    );
+    return res.results.map((u) => u.name);
+  } catch {
+    // Backend unavailable at generation time — ship the static entries only.
+    return [];
+  }
+}
+
+const getSitemapUsers = (workspaceId: string | null) =>
+  unstable_cache(async () => fetchUsersForWorkspace(workspaceId), ["sitemap-users", workspaceId ?? "platform"], {
+    revalidate: 86400
+  })();
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const metadata = await resolveSiteMetadata();
   const abs = (path: string) => new URL(path, metadata.origin).toString();
+
+  const h = await headers();
+  const workspaceId = h.get("x-owt-workspace-id");
 
   const staticEntries: MetadataRoute.Sitemap = [
     { url: abs("/"), changeFrequency: "daily", priority: 1 },
     { url: abs("/users"), changeFrequency: "daily", priority: 0.8 }
   ];
 
-  let userEntries: MetadataRoute.Sitemap = [];
-  try {
-    const res = await userService.getAll({
-      page: 1,
-      per_page: SITE_USER_CAP,
-      sort: "id",
-      order: SortDirection.asc,
-      query: "",
-      fields: [],
-      entities: []
-    });
-    userEntries = res.results.map((u) => ({
-      url: abs(`/users/${toUserSlug(u.name)}`),
-      changeFrequency: "weekly" as const,
-      priority: 0.6
-    }));
-  } catch {
-    // Backend unavailable at generation time — ship the static entries only.
-  }
+  const userNames = await getSitemapUsers(workspaceId);
+  const userEntries: MetadataRoute.Sitemap = userNames.map((name) => ({
+    url: abs(`/users/${toUserSlug(name)}`),
+    changeFrequency: "weekly" as const,
+    priority: 0.6
+  }));
 
   return [...staticEntries, ...userEntries];
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import userService from "@/services/user.service";
 import { SortDirection } from "@/types/pagination.types";
-import { SITE_URL_OBJ } from "@/config/site";
+import { resolveSiteMetadata } from "@/lib/site-metadata";
 import { toUserSlug } from "@/app/(site)/users/components/users-overview/utils";
 
 // Regenerated daily. NOTE: emits up to SITE_USER_CAP player profiles in a single
@@ -11,9 +11,10 @@ export const revalidate = 86400;
 
 const SITE_USER_CAP = 5000;
 
-const abs = (path: string) => new URL(path, SITE_URL_OBJ).toString();
-
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const metadata = await resolveSiteMetadata();
+  const abs = (path: string) => new URL(path, metadata.origin).toString();
+
   const staticEntries: MetadataRoute.Sitemap = [
     { url: abs("/"), changeFrequency: "daily", priority: 1 },
     { url: abs("/users"), changeFrequency: "daily", priority: 0.8 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -148,6 +148,15 @@ function isNavGroupActive(
   });
 }
 
+function workspaceInitials(name: string): string {
+  return name
+    .split(/[\s-]+/)
+    .slice(0, 2)
+    .map((w) => w[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
 interface HeaderProps {
   /**
    * True on a tenant (white-label) host — injected server-side from the
@@ -156,9 +165,14 @@ interface HeaderProps {
    * hidden. Absent/false on the apex/platform host.
    */
   tenantMode?: boolean;
+  /**
+   * The host workspace (name + icon) on a tenant host, resolved server-side.
+   * Rendered as a branded logo linking home in place of the switcher.
+   */
+  tenantWorkspace?: { name: string; iconUrl: string | null };
 }
 
-const Header = ({ tenantMode }: HeaderProps) => {
+const Header = ({ tenantMode, tenantWorkspace }: HeaderProps) => {
   const { user } = useAuthProfile();
   const pathname = usePathname() ?? "";
   const openAuthModal = useAuthModalStore((state) => state.open);
@@ -202,7 +216,35 @@ const Header = ({ tenantMode }: HeaderProps) => {
 
   return (
     <header className="sticky top-0 z-50 flex h-14 items-center gap-4 border-b border-border/70 bg-background/75 px-4 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 md:px-6">
-      {!tenantMode && <WorkspaceSwitcher />}
+      {tenantMode ? (
+        tenantWorkspace ? (
+          <Link
+            href="/"
+            aria-label={`${tenantWorkspace.name} — home`}
+            className="flex items-center gap-2 rounded-lg outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {tenantWorkspace.iconUrl ? (
+              // Plain <img> (not next/image) to avoid remote-domain config for
+              // arbitrary workspace icon hosts — same pattern as the switcher.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={tenantWorkspace.iconUrl}
+                alt=""
+                className="size-7 shrink-0 rounded-md object-cover"
+              />
+            ) : (
+              <span className="grid size-7 shrink-0 place-items-center rounded-md bg-[var(--aqt-teal)] text-xs font-semibold text-black">
+                {workspaceInitials(tenantWorkspace.name)}
+              </span>
+            )}
+            <span className="hidden max-w-[12rem] truncate text-sm font-semibold sm:inline">
+              {tenantWorkspace.name}
+            </span>
+          </Link>
+        ) : null
+      ) : (
+        <WorkspaceSwitcher />
+      )}
       <NavigationMenu className="hidden md:flex">
         {Object.keys(components)
           .filter((title) => title !== "Organization" || canAccessOrganization)

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -148,7 +148,17 @@ function isNavGroupActive(
   });
 }
 
-const Header = () => {
+interface HeaderProps {
+  /**
+   * True on a tenant (white-label) host — injected server-side from the
+   * `x-owt-host-mode` header (Task 6). The whole site is locked to one
+   * workspace there, so cross-workspace UI (the workspace switcher) is
+   * hidden. Absent/false on the apex/platform host.
+   */
+  tenantMode?: boolean;
+}
+
+const Header = ({ tenantMode }: HeaderProps) => {
   const { user } = useAuthProfile();
   const pathname = usePathname() ?? "";
   const openAuthModal = useAuthModalStore((state) => state.open);
@@ -192,7 +202,7 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 z-50 flex h-14 items-center gap-4 border-b border-border/70 bg-background/75 px-4 backdrop-blur-xl supports-[backdrop-filter]:bg-background/60 md:px-6">
-      <WorkspaceSwitcher />
+      {!tenantMode && <WorkspaceSwitcher />}
       <NavigationMenu className="hidden md:flex">
         {Object.keys(components)
           .filter((title) => title !== "Organization" || canAccessOrganization)

--- a/frontend/src/components/WorkspaceBootstrap.tsx
+++ b/frontend/src/components/WorkspaceBootstrap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
+import { resolveHost } from "@/lib/host";
 import { LEGACY_WORKSPACE_COOKIE, useWorkspaceStore, WORKSPACE_COOKIE } from "@/stores/workspace.store";
 
 export default function WorkspaceBootstrap() {
@@ -27,6 +28,13 @@ export default function WorkspaceBootstrap() {
   }, [fetchWorkspaces]);
 
   useEffect(() => {
+    // On a tenant (white-label) host the SSR is already scoped by the
+    // `x-owt-workspace-id` header (host beats cookie), the workspace is fixed,
+    // and no workspace cookie is written — so the cookie-absence "correction"
+    // below would fire a needless router.refresh()+invalidateQueries() on every
+    // load. Skip it entirely there.
+    const isTenantHost = resolveHost(window.location.hostname).mode === "tenant";
+
     const workspaceChanged =
       prevWorkspaceId.current !== null &&
       currentWorkspaceId !== null &&
@@ -40,7 +48,7 @@ export default function WorkspaceBootstrap() {
       !correctedInitialSsr.current &&
       currentWorkspaceId !== null;
 
-    if (workspaceChanged || needsInitialCorrection) {
+    if (!isTenantHost && (workspaceChanged || needsInitialCorrection)) {
       correctedInitialSsr.current = true;
       // Invalidate client-side React Query cache
       queryClient.invalidateQueries();

--- a/frontend/src/components/WorkspaceBootstrap.tsx
+++ b/frontend/src/components/WorkspaceBootstrap.tsx
@@ -3,9 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { useWorkspaceStore } from "@/stores/workspace.store";
-
-const WORKSPACE_COOKIE = "aqt-workspace-id";
+import { LEGACY_WORKSPACE_COOKIE, useWorkspaceStore, WORKSPACE_COOKIE } from "@/stores/workspace.store";
 
 export default function WorkspaceBootstrap() {
   const fetchWorkspaces = useWorkspaceStore((s) => s.fetchWorkspaces);
@@ -18,7 +16,9 @@ export default function WorkspaceBootstrap() {
   // components rendered unscoped (cross-workspace) data, so once we resolve the
   // active workspace on the client we must refresh them exactly once.
   const ssrHadWorkspaceCookie = useRef(
-    typeof document !== "undefined" && document.cookie.includes(`${WORKSPACE_COOKIE}=`)
+    typeof document !== "undefined" &&
+      (document.cookie.includes(`${WORKSPACE_COOKIE}=`) ||
+        document.cookie.includes(`${LEGACY_WORKSPACE_COOKIE}=`))
   );
   const correctedInitialSsr = useRef(false);
 

--- a/frontend/src/components/WorkspaceHostLock.tsx
+++ b/frontend/src/components/WorkspaceHostLock.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useWorkspaceStore } from "@/stores/workspace.store";
+
+/**
+ * Locks the client-side workspace store to the host's workspace on a tenant
+ * (white-label) host, so client-side `apiFetch` scoping and {@link
+ * WorkspaceThemeSync} match the server-side host lock (`x-owt-workspace-id`).
+ *
+ * `workspaceId` is resolved server-side in the `(site)` layout from the
+ * authoritative middleware header; `null` on the apex/platform host clears any
+ * lock so normal cookie-driven switching resumes.
+ */
+export function WorkspaceHostLock({ workspaceId }: { workspaceId: number | null }) {
+  const setHostLock = useWorkspaceStore((s) => s.setHostLock);
+
+  useEffect(() => {
+    setHostLock(workspaceId);
+  }, [workspaceId, setHostLock]);
+
+  return null;
+}

--- a/frontend/src/components/WorkspaceThemeSync.tsx
+++ b/frontend/src/components/WorkspaceThemeSync.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useWorkspaceStore } from "@/stores/workspace.store";
+import { applyWorkspacePalette, deriveWorkspacePalette } from "@/lib/workspace-theme";
+
+/**
+ * Keeps the main-site palette in sync with the selected workspace on the client.
+ *
+ * The `(site)` layout SSR-seeds the palette onto the `.site-theme` wrapper for a
+ * flash-free first paint. Switching workspaces only updates the store + cookie
+ * (no `router.refresh()`), so this component re-derives and imperatively applies
+ * the palette whenever the current workspace changes.
+ *
+ * It intentionally does nothing until the store has loaded its workspaces, so the
+ * SSR seed is never cleared in the gap before hydration completes.
+ */
+export function WorkspaceThemeSync() {
+  const currentWorkspaceId = useWorkspaceStore((s) => s.currentWorkspaceId);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+
+  useEffect(() => {
+    // Store not hydrated yet — leave the SSR seed untouched.
+    if (workspaces.length === 0) return;
+
+    const el = document.querySelector<HTMLElement>(".site-theme");
+    if (!el) return;
+
+    const current = workspaces.find((w) => w.id === currentWorkspaceId) ?? null;
+    applyWorkspacePalette(el, deriveWorkspacePalette(current));
+  }, [currentWorkspaceId, workspaces]);
+
+  return null;
+}

--- a/frontend/src/components/auth/AuthBootstrap.tsx
+++ b/frontend/src/components/auth/AuthBootstrap.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 
 import { isAuthRequiredPath } from "@/config/auth";
 import { AUTH_UNAUTHORIZED_EVENT } from "@/lib/auth-events";
-import { getTokenFromCookies, refreshAccessToken } from "@/lib/auth-tokens";
+import { getAccessTokenCookie, refreshAccessToken } from "@/lib/auth-tokens";
 import { isExpiredOrNearExpiry } from "@/lib/jwt";
 import { useProactiveTokenRefresh } from "@/lib/use-proactive-token-refresh";
 import { useAuthProfileStore } from "@/stores/auth-profile.store";
@@ -59,7 +59,7 @@ export default function AuthBootstrap() {
         // /auth/refresh on every focus while logged out.
         const currentStatus = useAuthProfileStore.getState().status;
         if (currentStatus !== "anonymous") {
-          const token = await getTokenFromCookies("aqt_access_token");
+          const token = await getAccessTokenCookie();
           if (isExpiredOrNearExpiry(token)) {
             await refreshAccessToken();
           }

--- a/frontend/src/lib/api-fetch.ts
+++ b/frontend/src/lib/api-fetch.ts
@@ -1,5 +1,5 @@
 import { cache } from "react";
-import { getTokenFromCookies } from "./auth-tokens";
+import { getAccessTokenCookie } from "./auth-tokens";
 import { retryWithRefreshOnUnauthorized } from "./auth-request";
 import { parseApiError } from "./api-error";
 import { useWorkspaceStore } from "@/stores/workspace.store";
@@ -202,7 +202,7 @@ export async function apiFetch(
   const url = qs ? `${baseUrl}${cleanPath}?${qs}` : `${baseUrl}${cleanPath}`;
 
   // Auth token
-  const initialToken = options.token ?? (await getTokenFromCookies("aqt_access_token"));
+  const initialToken = options.token ?? (await getAccessTokenCookie());
 
   // Headers
   const isFormData =

--- a/frontend/src/lib/api-fetch.ts
+++ b/frontend/src/lib/api-fetch.ts
@@ -76,9 +76,11 @@ function domainBehavior(path: string): DomainBehavior {
 
 const getServerWorkspaceId = cache(async (): Promise<string | undefined> => {
   try {
-    const { cookies } = await import("next/headers");
+    const { headers, cookies } = await import("next/headers");
+    const headerId = (await headers()).get("x-owt-workspace-id");
+    if (headerId) return headerId;
     const cookieStore = await cookies();
-    return cookieStore.get("aqt-workspace-id")?.value;
+    return cookieStore.get("owt-workspace-id")?.value ?? cookieStore.get("aqt-workspace-id")?.value;
   } catch {
     return undefined;
   }

--- a/frontend/src/lib/api-fetch.ts
+++ b/frontend/src/lib/api-fetch.ts
@@ -29,6 +29,12 @@ interface ApiFetchOptions {
   next?: { revalidate?: number | false; tags?: string[] };
   timeout?: number;
   skipWorkspace?: boolean;
+  /**
+   * Skip reading the access-token cookie (and thus `cookies()`). Required for
+   * callers running inside `unstable_cache`, where Next.js forbids dynamic APIs
+   * — e.g. the sitemap's public user fetch. Combine with `skipWorkspace`.
+   */
+  skipAuth?: boolean;
   throwOnError?: boolean;
 }
 
@@ -201,8 +207,9 @@ export async function apiFetch(
   const qs = params.toString();
   const url = qs ? `${baseUrl}${cleanPath}?${qs}` : `${baseUrl}${cleanPath}`;
 
-  // Auth token
-  const initialToken = options.token ?? (await getAccessTokenCookie());
+  // Auth token. `skipAuth` avoids reading the cookie (a dynamic API) — required
+  // for callers inside `unstable_cache` (e.g. the sitemap's public fetch).
+  const initialToken = options.skipAuth ? undefined : (options.token ?? (await getAccessTokenCookie()));
 
   // Headers
   const isFormData =

--- a/frontend/src/lib/auth-cookies.ts
+++ b/frontend/src/lib/auth-cookies.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { PLATFORM_ZONE } from "./host";
+
+// Canonical cookie names, written by oauth-callback.ts (login) and
+// auth/refresh/route.ts (refresh). LEGACY_* names are read as a fallback
+// during the aqt->owt rename so existing sessions are not logged out; they
+// are never written, only read and cleared.
+export const ACCESS_TOKEN_COOKIE = "owt_access_token";
+export const REFRESH_TOKEN_COOKIE = "owt_refresh_token";
+const LEGACY_ACCESS_TOKEN_COOKIE = "aqt_access_token";
+const LEGACY_REFRESH_TOKEN_COOKIE = "aqt_refresh_token";
+
+const IS_PROD = process.env.NODE_ENV === "production";
+// owt_access_token/owt_refresh_token are set Domain-wide (SSO across
+// subdomains) by oauth-callback.ts / auth/refresh/route.ts. A delete here
+// without the same Domain attribute doesn't clear that cookie — RFC 6265
+// keys a cookie by (name, domain, path), so a host-only delete would leave
+// the real domain-wide cookie in place (session resurrection) instead of
+// clearing it. Must match exactly.
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
+
+// Minimal structural type covering `await cookies()` (the
+// `ReadonlyRequestCookies` result of `next/headers`'s `cookies()`) without
+// depending on that type, which isn't re-exported from the public
+// `next/headers` entrypoint.
+interface CookieStore {
+  get(name: string): { value: string } | undefined;
+}
+
+// Deletes a Domain-wide `owt_*` cookie, replicating the exact attributes it
+// was set with so the browser treats this as an overwrite of the real
+// cookie rather than creating a second, competing one.
+function deleteOwtCookie(response: NextResponse, name: string): void {
+  response.cookies.delete({
+    name,
+    path: "/",
+    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {}),
+  });
+}
+
+// Reads the access-token cookie, preferring the canonical `owt_access_token`
+// name and falling back to the legacy `aqt_access_token` name so existing
+// sessions survive the aqt->owt rename.
+export function getAccessToken(store: CookieStore): string | undefined {
+  return store.get(ACCESS_TOKEN_COOKIE)?.value ?? store.get(LEGACY_ACCESS_TOKEN_COOKIE)?.value;
+}
+
+// Reads the refresh-token cookie with the same owt->aqt fallback as
+// getAccessToken.
+export function getRefreshToken(store: CookieStore): string | undefined {
+  return store.get(REFRESH_TOKEN_COOKIE)?.value ?? store.get(LEGACY_REFRESH_TOKEN_COOKIE)?.value;
+}
+
+// Clears BOTH generations of BOTH tokens on `response`. owt_* are
+// Domain-wide cookies in production — a delete without the same Domain
+// attribute creates a second, host-only cookie of the same name instead of
+// clearing the real one (RFC 6265 keys a cookie by name+domain+path), which
+// would leave the user silently still logged in on every subdomain (session
+// resurrection). aqt_* were always host-only, so a plain delete suffices for
+// them. Callers must route every "log the user out" site through this
+// helper so a partial future edit can't reintroduce that gap.
+export function clearAuthCookies(response: NextResponse): void {
+  deleteOwtCookie(response, ACCESS_TOKEN_COOKIE);
+  deleteOwtCookie(response, REFRESH_TOKEN_COOKIE);
+  response.cookies.delete(LEGACY_ACCESS_TOKEN_COOKIE);
+  response.cookies.delete(LEGACY_REFRESH_TOKEN_COOKIE);
+}

--- a/frontend/src/lib/auth-tokens.ts
+++ b/frontend/src/lib/auth-tokens.ts
@@ -1,10 +1,20 @@
 import { getTokenExpMs } from "./jwt";
+import { PLATFORM_ZONE } from "./host";
 
 // Canonical access-token cookie name. LEGACY_ACCESS_TOKEN_COOKIE is read as a
 // fallback during the aqt->owt rename so existing sessions are not logged out;
 // it is never written.
 const ACCESS_TOKEN_COOKIE = "owt_access_token";
 const LEGACY_ACCESS_TOKEN_COOKIE = "aqt_access_token";
+
+// Must match the Domain the server sets on login (oauth-callback.ts) /
+// refresh (auth/refresh/route.ts) in production. A client-side `Cookies.set`
+// without a matching Domain wouldn't overwrite that cookie — RFC 6265 keys a
+// cookie by (name, domain, path) — it would instead create a second,
+// host-only cookie with the same name, and which one a later request sends
+// first (stale domain-wide vs. fresh host-only) is undefined.
+const IS_PROD = process.env.NODE_ENV === "production";
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
 
 // Outcome of an access-token refresh attempt. The distinction matters: only a
 // genuinely dead session ("unauthenticated" — the refresh endpoint returned 401)
@@ -63,7 +73,8 @@ export async function setAccessTokenCookie(token: string): Promise<void> {
     Cookies.set(ACCESS_TOKEN_COOKIE, token, {
       path: "/",
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      secure: IS_PROD,
+      ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {}),
       ...(expMs !== undefined ? { expires: new Date(expMs) } : {}),
     });
   } catch {

--- a/frontend/src/lib/auth-tokens.ts
+++ b/frontend/src/lib/auth-tokens.ts
@@ -1,5 +1,11 @@
 import { getTokenExpMs } from "./jwt";
 
+// Canonical access-token cookie name. LEGACY_ACCESS_TOKEN_COOKIE is read as a
+// fallback during the aqt->owt rename so existing sessions are not logged out;
+// it is never written.
+const ACCESS_TOKEN_COOKIE = "owt_access_token";
+const LEGACY_ACCESS_TOKEN_COOKIE = "aqt_access_token";
+
 // Outcome of an access-token refresh attempt. The distinction matters: only a
 // genuinely dead session ("unauthenticated" — the refresh endpoint returned 401)
 // should log the user out. A transient failure ("error" — network/5xx) must NOT
@@ -31,6 +37,17 @@ export async function getTokenFromCookies(cookieName: string): Promise<string | 
   }
 }
 
+// Reads the access-token cookie, preferring the canonical `owt_access_token`
+// name and falling back to the legacy `aqt_access_token` name so existing
+// sessions survive the aqt->owt rename.
+export async function getAccessTokenCookie(): Promise<string | undefined> {
+  const token = await getTokenFromCookies(ACCESS_TOKEN_COOKIE);
+  if (token !== undefined) {
+    return token;
+  }
+  return getTokenFromCookies(LEGACY_ACCESS_TOKEN_COOKIE);
+}
+
 // Persist the access token in a JS-readable cookie whose lifetime matches the
 // token's own `exp`, so the client keeps the token exactly as long as it is
 // valid (and decides when to refresh by `exp`, instead of losing it early).
@@ -43,7 +60,7 @@ export async function setAccessTokenCookie(token: string): Promise<void> {
   try {
     const Cookies = (await import("js-cookie")).default;
     const expMs = getTokenExpMs(token);
-    Cookies.set("aqt_access_token", token, {
+    Cookies.set(ACCESS_TOKEN_COOKIE, token, {
       path: "/",
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",

--- a/frontend/src/lib/host.test.ts
+++ b/frontend/src/lib/host.test.ts
@@ -17,4 +17,11 @@ describe("resolveHost", () => {
     expect(resolveHost(`api.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
     expect(resolveHost(`a.b.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
   });
+
+  it("treats suffix-collision, foreign, and empty hosts as platform", () => {
+    // Leading-dot suffix check must NOT match a host that merely ends with the zone string.
+    expect(resolveHost(`evil${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+    expect(resolveHost("example.com")).toEqual({ mode: "platform" });
+    expect(resolveHost("")).toEqual({ mode: "platform" });
+  });
 });

--- a/frontend/src/lib/host.test.ts
+++ b/frontend/src/lib/host.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { PLATFORM_ZONE, resolveHost } from "@/lib/host";
+
+describe("resolveHost", () => {
+  it("treats apex + www as platform", () => {
+    expect(resolveHost(PLATFORM_ZONE)).toEqual({ mode: "platform" });
+    expect(resolveHost(`www.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+    expect(resolveHost(null)).toEqual({ mode: "platform" });
+  });
+
+  it("extracts a tenant subdomain", () => {
+    expect(resolveHost(`team-a.${PLATFORM_ZONE}`)).toEqual({ mode: "tenant", subdomain: "team-a" });
+    expect(resolveHost(`TEAM-A.${PLATFORM_ZONE}:443`)).toEqual({ mode: "tenant", subdomain: "team-a" });
+  });
+
+  it("rejects reserved + multi-segment labels as platform", () => {
+    expect(resolveHost(`api.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+    expect(resolveHost(`a.b.${PLATFORM_ZONE}`)).toEqual({ mode: "platform" });
+  });
+});

--- a/frontend/src/lib/host.ts
+++ b/frontend/src/lib/host.ts
@@ -1,0 +1,17 @@
+export const PLATFORM_ZONE = "owt.craazzzyyfoxx.me";
+
+const RESERVED = new Set([
+  "www", "api", "auth", "admin", "app", "assets", "static", "cdn", "mail", "ws",
+]);
+
+export type HostResolution = { mode: "platform" } | { mode: "tenant"; subdomain: string };
+
+export function resolveHost(host: string | null | undefined): HostResolution {
+  if (!host) return { mode: "platform" };
+  const hostname = host.trim().toLowerCase().split(":")[0];
+  const suffix = `.${PLATFORM_ZONE}`;
+  if (!hostname.endsWith(suffix)) return { mode: "platform" };
+  const label = hostname.slice(0, -suffix.length);
+  if (!label || label.includes(".") || RESERVED.has(label)) return { mode: "platform" };
+  return { mode: "tenant", subdomain: label };
+}

--- a/frontend/src/lib/oauth-callback.ts
+++ b/frontend/src/lib/oauth-callback.ts
@@ -68,7 +68,8 @@ export async function handleOAuthCallback(request: Request, provider: OAuthProvi
     const forwardedHeaders = getForwardedClientHeaders(request);
 
     if (oauthAction === "link") {
-      const accessToken = cookieStore.get("aqt_access_token")?.value;
+      const accessToken =
+        cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
       if (!accessToken) {
         const loginUrl = new URL("/", SITE_URL);
@@ -84,7 +85,7 @@ export async function handleOAuthCallback(request: Request, provider: OAuthProvi
     const tokens = await authService.exchangeOAuthCode(provider, code, state, forwardedHeaders);
     const response = createRedirectResponse(resolveSafeRedirect(postLoginRedirect));
 
-    response.cookies.set("aqt_access_token", tokens.access_token, {
+    response.cookies.set("owt_access_token", tokens.access_token, {
       httpOnly: false,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",
@@ -92,7 +93,7 @@ export async function handleOAuthCallback(request: Request, provider: OAuthProvi
       maxAge: getTokenMaxAgeSeconds(tokens.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS)
     });
 
-    response.cookies.set("aqt_refresh_token", tokens.refresh_token, {
+    response.cookies.set("owt_refresh_token", tokens.refresh_token, {
       httpOnly: true,
       sameSite: "lax",
       secure: process.env.NODE_ENV === "production",

--- a/frontend/src/lib/oauth-callback.ts
+++ b/frontend/src/lib/oauth-callback.ts
@@ -2,39 +2,127 @@ import { NextResponse } from "next/server";
 import { authService } from "@/services/auth.service";
 import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { getTokenMaxAgeSeconds } from "@/lib/jwt";
+import { resolveHost, PLATFORM_ZONE } from "@/lib/host";
 import type { OAuthProviderName } from "@/types/auth.types";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+const IS_PROD = process.env.NODE_ENV === "production";
 
 // Cookie lifetime used when the access token's `exp` can't be decoded.
 const FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS = 13 * 60;
+const REFRESH_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
 
-function createRedirectResponse(redirectUrl: URL, clearOAuthCookies: boolean = true): NextResponse {
-  const response = NextResponse.redirect(redirectUrl);
-  if (clearOAuthCookies) {
-    response.cookies.delete("aqt_oauth_state");
-    response.cookies.delete("aqt_post_login_redirect");
-    response.cookies.delete("aqt_oauth_action");
-    response.cookies.delete("aqt_oauth_provider");
+// Session cookies are readable across every subdomain (SSO) in production;
+// omitted in dev since `localhost` has no registrable platform-zone domain.
+const COOKIE_DOMAIN = `.${PLATFORM_ZONE}`;
+
+// Browser-binding CSRF cookie set by startOAuthLogin (oauth-login.ts). Single
+// use: read once here, forwarded raw to the backend, then always cleared.
+const CSRF_COOKIE = "owt_oauth_csrf";
+
+const KNOWN_PROVIDERS: ReadonlySet<OAuthProviderName> = new Set<OAuthProviderName>([
+  "discord",
+  "twitch",
+  "battlenet",
+]);
+
+// Only redirect back to the platform apex or a valid tenant subdomain. The
+// `origin` field on the exchange/link response is echoed back from the
+// signed state, but the state's `origin` claim is only as trustworthy as
+// whatever Host header started the flow — never redirect to it unchecked.
+function isAllowedOrigin(origin: string): boolean {
+  try {
+    const u = new URL(origin);
+    if (u.hostname === PLATFORM_ZONE) return true;
+    return resolveHost(u.hostname).mode === "tenant";
+  } catch {
+    return false;
   }
+}
+
+// `redirect` (from the exchange response, itself echoed from the HMAC-signed
+// state) is only constrained to a same-origin path by the *sender's* own
+// discipline (oauth-login.ts's `nextUrl.origin === origin` clamp) — the RPC
+// boundary (`rpc_oauth_url`) never validates its shape, so nothing here can
+// assume it's safe. Constructing `new URL(redirect, origin)` directly would
+// let an absolute URL, a protocol-relative `//evil.com`, or a backslash trick
+// (`/\evil.com`, which WHATWG URL parsing normalizes to `//evil.com` for
+// http(s)) silently escape `origin` entirely — a classic OAuth-state open
+// redirect. Let the URL parser do the normalization, then verify the
+// *resulting* origin still matches before trusting it.
+function safeRedirectTarget(redirect: string, origin: string): URL {
+  try {
+    const target = new URL(redirect || "/", origin);
+    if (target.origin === new URL(origin).origin) return target;
+  } catch {
+    // fall through to the safe default below
+  }
+  return new URL("/", origin);
+}
+
+function base64UrlDecodeToString(value: string): string {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  return atob(padded);
+}
+
+interface StateRouting {
+  action: "login" | "link";
+  provider: OAuthProviderName | null;
+}
+
+// Best-effort, UNTRUSTED decode of the signed OAuth state — used only to pick
+// which provider/endpoint this apex callback should call next (there is a
+// single fixed OAuth redirect_uri for every provider, so nothing else on this
+// request tells us which one just completed). The backend independently
+// HMAC-verifies the state and cross-checks provider/action server-side
+// (`oauth_flows._verify_state_for`), so a tampered/forged read here can only
+// misroute the request to the wrong endpoint (which then fails verification),
+// never bypass verification itself. State shape is
+// `base64url(payloadJson).base64url(signature)` with short JSON keys:
+// {"o": origin, "r": redirect, "a": action, "p": provider, "n": nonce, "e": exp}
+// (confirmed against backend/identity-service's StatePayload, Task 9 report).
+// A decode failure defaults to the login action per the brief; provider has
+// no safe default (we'd have no endpoint to call), so it's null and the
+// caller must fail closed on that.
+function decodeStateForRouting(state: string): StateRouting {
+  try {
+    const payloadPart = state.split(".")[0];
+    const json = JSON.parse(base64UrlDecodeToString(payloadPart)) as Record<string, unknown>;
+    const action: "login" | "link" = json.a === "link" ? "link" : "login";
+    const provider =
+      typeof json.p === "string" && KNOWN_PROVIDERS.has(json.p as OAuthProviderName)
+        ? (json.p as OAuthProviderName)
+        : null;
+    return { action, provider };
+  } catch {
+    return { action: "login", provider: null };
+  }
+}
+
+// Clears the single-use CSRF cookie. Must be called with the same Domain/Path
+// attributes it was set with (oauth-login.ts) or the browser won't treat this
+// as an overwrite of the original cookie.
+function clearCsrfCookie(response: NextResponse): void {
+  response.cookies.delete({
+    name: CSRF_COOKIE,
+    path: "/",
+    ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
+  });
+}
+
+function errorRedirect(errorCode: string, description?: string | null): NextResponse {
+  const errorUrl = new URL("/", SITE_URL);
+  errorUrl.searchParams.set("auth_error", errorCode);
+  if (description) {
+    errorUrl.searchParams.set("auth_error_description", description);
+  }
+  const response = NextResponse.redirect(errorUrl);
+  clearCsrfCookie(response);
   return response;
 }
 
-function resolveSafeRedirect(postLoginRedirect: string): URL {
-  try {
-    const redirectUrl = new URL(postLoginRedirect, SITE_URL);
-    const siteOrigin = new URL(SITE_URL).origin;
-    if (redirectUrl.origin === siteOrigin) {
-      return redirectUrl;
-    }
-  } catch {
-    return new URL("/", SITE_URL);
-  }
-
-  return new URL("/", SITE_URL);
-}
-
-export async function handleOAuthCallback(request: Request, provider: OAuthProviderName): Promise<NextResponse> {
+export async function handleOAuthCallback(request: Request): Promise<NextResponse> {
   const { cookies } = await import("next/headers");
 
   const url = new URL(request.url);
@@ -43,31 +131,29 @@ export async function handleOAuthCallback(request: Request, provider: OAuthProvi
   const error = url.searchParams.get("error");
   const errorDescription = url.searchParams.get("error_description");
 
-  const cookieStore = await cookies();
-  const expectedState = cookieStore.get("aqt_oauth_state")?.value;
-  const oauthAction = cookieStore.get("aqt_oauth_action")?.value;
-  const storedProvider = cookieStore.get("aqt_oauth_provider")?.value;
-  const postLoginRedirect = cookieStore.get("aqt_post_login_redirect")?.value || "/";
-
   if (error) {
-    const errorUrl = new URL("/", SITE_URL);
-    errorUrl.searchParams.set("auth_error", error);
-    if (errorDescription) {
-      errorUrl.searchParams.set("auth_error_description", errorDescription);
-    }
-    return createRedirectResponse(errorUrl);
+    return errorRedirect(error, errorDescription);
   }
 
-  if (!code || !state || !expectedState || state !== expectedState || storedProvider !== provider) {
-    const errorUrl = new URL("/", SITE_URL);
-    errorUrl.searchParams.set("auth_error", "invalid_state");
-    return createRedirectResponse(errorUrl);
+  const cookieStore = await cookies();
+  const csrf = cookieStore.get(CSRF_COOKIE)?.value;
+
+  // Fail closed: the backend independently rejects a missing/mismatched csrf
+  // (Task 9b's `_verify_csrf_binding`), but there's no reason to spend an RPC
+  // round trip on a request that's already missing something required.
+  if (!code || !state || !csrf) {
+    return errorRedirect("invalid_state");
+  }
+
+  const { action, provider } = decodeStateForRouting(state);
+  if (!provider) {
+    return errorRedirect("invalid_provider");
   }
 
   try {
     const forwardedHeaders = getForwardedClientHeaders(request);
 
-    if (oauthAction === "link") {
+    if (action === "link") {
       const accessToken =
         cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
 
@@ -75,37 +161,46 @@ export async function handleOAuthCallback(request: Request, provider: OAuthProvi
         const loginUrl = new URL("/", SITE_URL);
         loginUrl.searchParams.set("login", "1");
         loginUrl.searchParams.set("next", "/account");
-        return createRedirectResponse(loginUrl);
+        const response = NextResponse.redirect(loginUrl);
+        clearCsrfCookie(response);
+        return response;
       }
 
-      await authService.linkOAuth(provider, code, state, accessToken, forwardedHeaders);
-      return createRedirectResponse(new URL("/account", SITE_URL));
+      const linkResult = await authService.linkOAuth(provider, code, state, accessToken, csrf, forwardedHeaders);
+      const origin = isAllowedOrigin(linkResult.origin) ? linkResult.origin : `https://${PLATFORM_ZONE}`;
+
+      const response = NextResponse.redirect(new URL("/account", origin));
+      clearCsrfCookie(response);
+      return response;
     }
 
-    const tokens = await authService.exchangeOAuthCode(provider, code, state, forwardedHeaders);
-    const response = createRedirectResponse(resolveSafeRedirect(postLoginRedirect));
+    const result = await authService.exchangeOAuthCode(provider, code, state, csrf, forwardedHeaders);
+    const origin = isAllowedOrigin(result.origin) ? result.origin : `https://${PLATFORM_ZONE}`;
+    const target = safeRedirectTarget(result.redirect, origin);
 
-    response.cookies.set("owt_access_token", tokens.access_token, {
+    const response = NextResponse.redirect(target);
+    response.cookies.set("owt_access_token", result.access_token, {
       httpOnly: false,
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      secure: IS_PROD,
       path: "/",
-      maxAge: getTokenMaxAgeSeconds(tokens.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS)
+      maxAge: getTokenMaxAgeSeconds(result.access_token, FALLBACK_ACCESS_COOKIE_MAX_AGE_SECONDS),
+      ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
     });
 
-    response.cookies.set("owt_refresh_token", tokens.refresh_token, {
+    response.cookies.set("owt_refresh_token", result.refresh_token, {
       httpOnly: true,
       sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
+      secure: IS_PROD,
       path: "/",
-      maxAge: 30 * 24 * 60 * 60
+      maxAge: REFRESH_COOKIE_MAX_AGE_SECONDS,
+      ...(IS_PROD ? { domain: COOKIE_DOMAIN } : {})
     });
 
+    clearCsrfCookie(response);
     return response;
   } catch (err) {
     console.error("OAuth callback error:", err);
-    const errorUrl = new URL("/", SITE_URL);
-    errorUrl.searchParams.set("auth_error", "exchange_failed");
-    return createRedirectResponse(errorUrl);
+    return errorRedirect("exchange_failed");
   }
 }

--- a/frontend/src/lib/oauth-callback.ts
+++ b/frontend/src/lib/oauth-callback.ts
@@ -3,6 +3,7 @@ import { authService } from "@/services/auth.service";
 import { getForwardedClientHeaders } from "@/lib/forward-client-headers";
 import { getTokenMaxAgeSeconds } from "@/lib/jwt";
 import { resolveHost, PLATFORM_ZONE } from "@/lib/host";
+import { getAccessToken } from "@/lib/auth-cookies";
 import type { OAuthProviderName } from "@/types/auth.types";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
@@ -154,8 +155,7 @@ export async function handleOAuthCallback(request: Request): Promise<NextRespons
     const forwardedHeaders = getForwardedClientHeaders(request);
 
     if (action === "link") {
-      const accessToken =
-        cookieStore.get("owt_access_token")?.value ?? cookieStore.get("aqt_access_token")?.value;
+      const accessToken = getAccessToken(cookieStore);
 
       if (!accessToken) {
         const loginUrl = new URL("/", SITE_URL);

--- a/frontend/src/lib/oauth-login.ts
+++ b/frontend/src/lib/oauth-login.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { authService } from "@/services/auth.service";
 import type { OAuthProviderName } from "@/types/auth.types";
+import { PLATFORM_ZONE } from "@/lib/host";
 
 // Browser-binding CSRF cookie for the OAuth start->callback round trip. The
 // signed state (produced by the backend) carries origin/redirect/action and
@@ -46,7 +47,7 @@ export async function startOAuthLogin(request: Request, provider: OAuthProviderN
     // Readable on the apex callback host regardless of which subdomain
     // started the flow. Omitted outside production so localhost (no
     // registrable platform-zone domain) still works.
-    ...(process.env.NODE_ENV === "production" ? { domain: ".owt.craazzzyyfoxx.me" } : {})
+    ...(process.env.NODE_ENV === "production" ? { domain: `.${PLATFORM_ZONE}` } : {})
   });
 
   return response;

--- a/frontend/src/lib/oauth-login.ts
+++ b/frontend/src/lib/oauth-login.ts
@@ -1,68 +1,52 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { authService } from "@/services/auth.service";
 import type { OAuthProviderName } from "@/types/auth.types";
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "/";
+// Browser-binding CSRF cookie for the OAuth start->callback round trip. The
+// signed state (produced by the backend) carries origin/redirect/action and
+// binds sha256(csrf) into itself; the raw value only ever lives in this
+// HttpOnly cookie. An attacker who can trigger the flow (e.g. via a hidden
+// <img>/<a> to /auth/discord/login) cannot read or set this cookie for the
+// victim, so the callback's cookie/state-hash comparison (Task 11) fails
+// closed on login/linking CSRF.
+const CSRF_COOKIE = "owt_oauth_csrf";
+const CSRF_COOKIE_MAX_AGE_SECONDS = 10 * 60;
+
+function generateCsrfToken(): string {
+  // Two concatenated random UUIDs: well over 128 bits of entropy, generated
+  // via the platform's CSPRNG (Node/Bun webcrypto), not Math.random().
+  return `${crypto.randomUUID()}${crypto.randomUUID()}`.replace(/-/g, "");
+}
 
 export async function startOAuthLogin(request: Request, provider: OAuthProviderName): Promise<NextResponse> {
   const { searchParams, origin } = new URL(request.url);
   const nextParam = searchParams.get("next");
   const action = searchParams.get("action") === "link" ? "link" : "login";
 
-  let next = SITE_URL;
+  let redirect = action === "link" ? "/account" : "/";
   if (nextParam) {
     try {
       const nextUrl = new URL(nextParam, origin);
-      if (nextUrl.origin === origin) {
-        next = nextUrl.pathname + nextUrl.search;
-      }
+      if (nextUrl.origin === origin) redirect = nextUrl.pathname + nextUrl.search;
     } catch {
-      if (nextParam.startsWith("/")) {
-        next = nextParam;
-      }
+      if (nextParam.startsWith("/")) redirect = nextParam;
     }
-  } else if (action === "link") {
-    next = "/account";
-  } else if (SITE_URL) {
-    next = SITE_URL;
   }
 
-  const { url, state } = await authService.getOAuthUrl(provider);
-
-  await cookies();
+  const csrf = generateCsrfToken();
+  const { url } = await authService.getOAuthUrl(provider, { origin, redirect, action, csrf });
 
   const response = NextResponse.redirect(url);
-  response.cookies.set("aqt_oauth_state", state, {
+  response.cookies.set(CSRF_COOKIE, csrf, {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
     path: "/",
-    maxAge: 10 * 60
-  });
-
-  response.cookies.set("aqt_post_login_redirect", next, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 10 * 60
-  });
-
-  response.cookies.set("aqt_oauth_action", action, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 10 * 60
-  });
-
-  response.cookies.set("aqt_oauth_provider", provider, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 10 * 60
+    maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+    // Readable on the apex callback host regardless of which subdomain
+    // started the flow. Omitted outside production so localhost (no
+    // registrable platform-zone domain) still works.
+    ...(process.env.NODE_ENV === "production" ? { domain: ".owt.craazzzyyfoxx.me" } : {})
   });
 
   return response;

--- a/frontend/src/lib/site-metadata.ts
+++ b/frontend/src/lib/site-metadata.ts
@@ -1,0 +1,60 @@
+import { headers } from "next/headers";
+import workspaceService from "@/services/workspace.service";
+import { SITE_NAME, SITE_URL } from "@/config/site";
+
+export interface SiteMetadata {
+  name: string;
+  description: string;
+  origin: string;
+  icon: string;
+}
+
+function platformDefaults(origin: string): SiteMetadata {
+  return {
+    name: SITE_NAME,
+    description: `${SITE_NAME} — Overwatch tournament results & stats.`,
+    origin,
+    icon: "/favicon.ico"
+  };
+}
+
+/**
+ * Per-request SEO metadata, resolved from the tenant host's workspace.
+ *
+ * On a tenant host, `middleware.ts` (Task 6) injects `x-owt-workspace-id`
+ * ahead of the request. When present, the workspace's own SEO fields
+ * (`seo_title` / `seo_description` / `icon_url`) drive the page title, OG
+ * tags, and favicon, and `origin` becomes the tenant host itself (so
+ * `metadataBase`/canonical resolve to that subdomain). On the apex host (no
+ * workspace header) — or if anything above fails, including reading the
+ * request headers themselves — this falls back to the platform defaults.
+ * Never throws: callers can await this unconditionally in
+ * `generateMetadata()`.
+ */
+export async function resolveSiteMetadata(): Promise<SiteMetadata> {
+  try {
+    const h = await headers();
+    const host = h.get("x-forwarded-host") ?? h.get("host") ?? "owt.craazzzyyfoxx.me";
+    const proto = h.get("x-forwarded-proto") ?? "https";
+    const origin = `${proto}://${host.split(",")[0].trim()}`;
+
+    const wsId = h.get("x-owt-workspace-id");
+    if (!wsId) {
+      return platformDefaults(origin);
+    }
+
+    try {
+      const ws = await workspaceService.getById(Number(wsId));
+      return {
+        name: ws.seo_title ?? ws.name,
+        description: ws.seo_description ?? ws.description ?? `${ws.name} — tournaments`,
+        origin,
+        icon: ws.icon_url ?? "/favicon.ico"
+      };
+    } catch {
+      return platformDefaults(origin);
+    }
+  } catch {
+    return platformDefaults(SITE_URL);
+  }
+}

--- a/frontend/src/lib/site-metadata.ts
+++ b/frontend/src/lib/site-metadata.ts
@@ -1,6 +1,6 @@
 import { headers } from "next/headers";
 import workspaceService from "@/services/workspace.service";
-import { SITE_NAME, SITE_URL } from "@/config/site";
+import { SITE_NAME, SITE_URL, SITE_URL_OBJ, SITE_FAVICON } from "@/config/site";
 
 export interface SiteMetadata {
   name: string;
@@ -14,7 +14,7 @@ function platformDefaults(origin: string): SiteMetadata {
     name: SITE_NAME,
     description: `${SITE_NAME} — Overwatch tournament results & stats.`,
     origin,
-    icon: "/favicon.ico"
+    icon: SITE_FAVICON
   };
 }
 
@@ -34,9 +34,16 @@ function platformDefaults(origin: string): SiteMetadata {
 export async function resolveSiteMetadata(): Promise<SiteMetadata> {
   try {
     const h = await headers();
-    const host = h.get("x-forwarded-host") ?? h.get("host") ?? "owt.craazzzyyfoxx.me";
-    const proto = h.get("x-forwarded-proto") ?? "https";
-    const origin = `${proto}://${host.split(",")[0].trim()}`;
+    const host = (h.get("x-forwarded-host") ?? h.get("host") ?? "").split(",")[0]?.trim();
+    const proto = h.get("x-forwarded-proto")?.split(",")[0]?.trim() || "https";
+    let origin = SITE_URL_OBJ.origin;
+    if (host) {
+      try {
+        origin = new URL(`${proto}://${host}`).origin;
+      } catch {
+        origin = SITE_URL_OBJ.origin;
+      }
+    }
 
     const wsId = h.get("x-owt-workspace-id");
     if (!wsId) {
@@ -49,12 +56,12 @@ export async function resolveSiteMetadata(): Promise<SiteMetadata> {
         name: ws.seo_title ?? ws.name,
         description: ws.seo_description ?? ws.description ?? `${ws.name} — tournaments`,
         origin,
-        icon: ws.icon_url ?? "/favicon.ico"
+        icon: ws.icon_url ?? SITE_FAVICON
       };
     } catch {
       return platformDefaults(origin);
     }
   } catch {
-    return platformDefaults(SITE_URL);
+    return platformDefaults(SITE_URL_OBJ.origin);
   }
 }

--- a/frontend/src/lib/use-proactive-token-refresh.ts
+++ b/frontend/src/lib/use-proactive-token-refresh.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-import { getTokenFromCookies, refreshAccessToken } from "@/lib/auth-tokens";
+import { getAccessTokenCookie, refreshAccessToken } from "@/lib/auth-tokens";
 import { getTokenExpMs } from "@/lib/jwt";
 
 const REFRESH_SKEW_MS = 60_000; // refresh ~1 min before the token expires
@@ -54,7 +54,7 @@ export function useProactiveTokenRefresh(enabled: boolean, onSessionDead: () => 
     };
 
     void (async () => {
-      const token = await getTokenFromCookies("aqt_access_token");
+      const token = await getAccessTokenCookie();
       schedule(computeDelay(token));
     })();
 

--- a/frontend/src/lib/workspace-theme.test.ts
+++ b/frontend/src/lib/workspace-theme.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+
+import type { WorkspaceBranding } from "@/types/workspace.types";
+import {
+  deriveWorkspacePalette,
+  parseHex,
+  rgbToHsl,
+  WORKSPACE_THEME_VAR_NAMES,
+} from "@/lib/workspace-theme";
+
+const FULL: WorkspaceBranding = {
+  branding_enabled: true,
+  brand_primary: "#14b8a6",
+  brand_secondary: "#8b5cf6",
+  brand_background: "#0b1220",
+  brand_surface: "#111a2b",
+};
+
+function lightnessOf(triplet: string): number {
+  // "H S% L%" → L
+  const match = triplet.match(/(\d+)%\s*$/);
+  return match ? Number(match[1]) : NaN;
+}
+
+describe("deriveWorkspacePalette", () => {
+  it("returns null when branding is disabled", () => {
+    expect(deriveWorkspacePalette({ ...FULL, branding_enabled: false })).toBeNull();
+  });
+
+  it("returns null when branding is missing", () => {
+    expect(deriveWorkspacePalette(null)).toBeNull();
+    expect(deriveWorkspacePalette(undefined)).toBeNull();
+  });
+
+  it("returns null without the minimum colours (primary + background)", () => {
+    expect(deriveWorkspacePalette({ ...FULL, brand_primary: null })).toBeNull();
+    expect(deriveWorkspacePalette({ ...FULL, brand_background: null })).toBeNull();
+    expect(deriveWorkspacePalette({ ...FULL, brand_primary: "not-a-color" })).toBeNull();
+  });
+
+  it("builds exactly the exported variable set (no drift, no extras)", () => {
+    const palette = deriveWorkspacePalette(FULL)!;
+    expect(palette).not.toBeNull();
+    expect(new Set(Object.keys(palette))).toEqual(new Set(WORKSPACE_THEME_VAR_NAMES));
+  });
+
+  it("uses full hsl() for --aqt-* and bare triplets for shadcn tokens", () => {
+    const palette = deriveWorkspacePalette(FULL)!;
+    expect(palette["--aqt-bg"]).toMatch(/^hsl\(\d+ \d+% \d+%\)$/);
+    expect(palette["--aqt-teal"]).toMatch(/^hsl\(\d+ \d+% \d+%\)$/);
+    expect(palette["--background"]).toMatch(/^\d+ \d+% \d+%$/);
+    expect(palette["--primary"]).toMatch(/^\d+ \d+% \d+%$/);
+  });
+
+  it("clamps an arbitrarily light background into the dark band", () => {
+    const palette = deriveWorkspacePalette({
+      ...FULL,
+      brand_background: "#ffffff",
+      brand_surface: "#f0f0f0",
+    })!;
+    expect(lightnessOf(palette["--background"])).toBeLessThanOrEqual(14);
+    expect(lightnessOf(palette["--background"])).toBeGreaterThanOrEqual(4);
+    // --aqt-bg mirrors --background (dark)
+    const aqtL = Number(palette["--aqt-bg"].match(/(\d+)%\)$/)?.[1]);
+    expect(aqtL).toBeLessThanOrEqual(14);
+  });
+
+  it("contrast-picks a DARK foreground on a bright accent", () => {
+    const palette = deriveWorkspacePalette({ ...FULL, brand_primary: "#ffd400" })!;
+    expect(palette["--primary-foreground"]).toBe("0 0% 9%");
+  });
+
+  it("contrast-picks a LIGHT foreground on a dark accent", () => {
+    const palette = deriveWorkspacePalette({ ...FULL, brand_primary: "#001133" })!;
+    expect(palette["--primary-foreground"]).toBe("0 0% 98%");
+  });
+
+  it("never overrides semantic role / status / chart tokens", () => {
+    const palette = deriveWorkspacePalette(FULL)!;
+    for (const forbidden of [
+      "--aqt-tank",
+      "--aqt-damage",
+      "--aqt-support",
+      "--aqt-emerald",
+      "--aqt-amber",
+      "--aqt-gold",
+      "--aqt-rose",
+      "--aqt-blue",
+      "--destructive",
+      "--chart-1",
+    ]) {
+      expect(palette[forbidden]).toBeUndefined();
+    }
+  });
+
+  it("falls back to primary/background when secondary + surface are absent", () => {
+    const palette = deriveWorkspacePalette({
+      ...FULL,
+      brand_secondary: null,
+      brand_surface: null,
+    })!;
+    expect(palette).not.toBeNull();
+    expect(new Set(Object.keys(palette))).toEqual(new Set(WORKSPACE_THEME_VAR_NAMES));
+    // secondary falls back to the (clamped) primary accent
+    expect(palette["--aqt-violet"]).toBe(palette["--aqt-teal"]);
+  });
+});
+
+describe("parseHex", () => {
+  it("parses #RRGGBB", () => {
+    expect(parseHex("#ffffff")).toEqual({ r: 255, g: 255, b: 255 });
+    expect(parseHex("#000000")).toEqual({ r: 0, g: 0, b: 0 });
+  });
+
+  it("expands #RGB shorthand", () => {
+    expect(parseHex("#0f8")).toEqual({ r: 0, g: 255, b: 136 });
+  });
+
+  it("rejects malformed input", () => {
+    expect(parseHex("red")).toBeNull();
+    expect(parseHex("#12")).toBeNull();
+    expect(parseHex(null)).toBeNull();
+    expect(parseHex("")).toBeNull();
+  });
+});
+
+describe("rgbToHsl", () => {
+  it("computes hue for a pure primary", () => {
+    expect(rgbToHsl({ r: 255, g: 0, b: 0 }).h).toBeCloseTo(0, 0);
+    expect(rgbToHsl({ r: 0, g: 255, b: 0 }).h).toBeCloseTo(120, 0);
+    expect(rgbToHsl({ r: 0, g: 0, b: 255 }).h).toBeCloseTo(240, 0);
+  });
+});

--- a/frontend/src/lib/workspace-theme.ts
+++ b/frontend/src/lib/workspace-theme.ts
@@ -1,0 +1,293 @@
+/**
+ * Workspace site branding — derive a full CSS-variable override set from the 4
+ * organiser-controlled brand colours.
+ *
+ * Single source of truth for both the SSR seed (in the `(site)` layout) and the
+ * client-side {@link WorkspaceThemeSync}. Pure + deterministic so it is trivially
+ * unit-testable.
+ *
+ * FORMAT FOOTGUN — two different value formats live in this map:
+ *   - `--aqt-*` tokens hold a COMPLETE colour, e.g. `hsl(174 72% 46%)`
+ *     (consumed as `var(--aqt-teal)`).
+ *   - shadcn tokens (`--primary`, `--background`, …) hold a BARE HSL triplet,
+ *     e.g. `174 72% 46%` (consumed as `hsl(var(--primary))`).
+ *
+ * The app is dark-only, so background/surface are clamped into a dark lightness
+ * band to keep the (light) foreground readable; accents are clamped into a
+ * usable band and their on-accent foreground is contrast-picked (WCAG).
+ *
+ * Semantic tokens are deliberately NOT overridden — OW role colours
+ * (`--aqt-tank/-damage/-support`), status hues (`--aqt-emerald/-amber/-gold`),
+ * chart colours and `--destructive` carry meaning and must stay stable.
+ */
+import type { Workspace, WorkspaceBranding } from "@/types/workspace.types";
+
+export type CssVarMap = Record<string, string>;
+
+interface Hsl {
+  h: number;
+  s: number;
+  l: number;
+}
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// Dark-only invariant: keep page/surface dark so the light foreground stays legible.
+const DARK_BG = { min: 4, max: 14 } as const;
+const DARK_SURFACE = { min: 6, max: 16 } as const;
+// Keep accents vivid + legible on a dark canvas without fully discarding the pick.
+const ACCENT_L = { min: 40, max: 70 } as const;
+const ACCENT_S_MIN = 30;
+
+// Every CSS variable this module may set. Exported so the client sync can clear
+// the whole set when switching to an unbranded workspace. Kept in lockstep with
+// the map built below (a unit test asserts they match).
+export const WORKSPACE_THEME_VAR_NAMES: readonly string[] = [
+  // --aqt-* (full hsl(...))
+  "--aqt-bg",
+  "--aqt-bg-2",
+  "--aqt-card",
+  "--aqt-card-2",
+  "--aqt-border",
+  "--aqt-border-2",
+  "--aqt-border-3",
+  "--aqt-fg",
+  "--aqt-fg-muted",
+  "--aqt-fg-dim",
+  "--aqt-fg-faint",
+  "--aqt-teal",
+  "--aqt-violet",
+  // shadcn (bare "H S% L%")
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--popover",
+  "--popover-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--border",
+  "--input",
+  "--ring",
+];
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+/** Parse `#RRGGBB` (or `#rgb`) → rgb, or null if malformed. */
+export function parseHex(hex: string | null | undefined): Rgb | null {
+  if (!hex) return null;
+  let value = hex.trim().replace(/^#/, "");
+  if (value.length === 3) {
+    value = value
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(value)) return null;
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+export function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const l = (max + min) / 2;
+
+  let h = 0;
+  let s = 0;
+  if (delta !== 0) {
+    s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / delta + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / delta + 2;
+        break;
+      default:
+        h = (rn - gn) / delta + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return { h, s: s * 100, l: l * 100 };
+}
+
+function hue2rgb(p: number, q: number, t: number): number {
+  let tt = t;
+  if (tt < 0) tt += 1;
+  if (tt > 1) tt -= 1;
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+  if (tt < 1 / 2) return q;
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+  return p;
+}
+
+export function hslToRgb({ h, s, l }: Hsl): Rgb {
+  const hn = ((h % 360) + 360) % 360 / 360;
+  const sn = clamp(s, 0, 100) / 100;
+  const ln = clamp(l, 0, 100) / 100;
+  if (sn === 0) {
+    const v = Math.round(ln * 255);
+    return { r: v, g: v, b: v };
+  }
+  const q = ln < 0.5 ? ln * (1 + sn) : ln + sn - ln * sn;
+  const p = 2 * ln - q;
+  return {
+    r: Math.round(hue2rgb(p, q, hn + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, hn) * 255),
+    b: Math.round(hue2rgb(p, q, hn - 1 / 3) * 255),
+  };
+}
+
+/** WCAG relative luminance of an sRGB colour. */
+function relLuminance({ r, g, b }: Rgb): number {
+  const lin = [r, g, b].map((c) => {
+    const cs = c / 255;
+    return cs <= 0.03928 ? cs / 12.92 : Math.pow((cs + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+
+const FG_LIGHT = "0 0% 98%";
+const FG_DARK = "0 0% 9%";
+
+/** Pick black/white foreground for text sitting on `bg`, by WCAG contrast. */
+function pickOnColorForeground(bg: Rgb): string {
+  const lum = relLuminance(bg);
+  const contrastWhite = 1.05 / (lum + 0.05);
+  const contrastBlack = (lum + 0.05) / 0.05;
+  return contrastBlack > contrastWhite ? FG_DARK : FG_LIGHT;
+}
+
+const round = (n: number): number => Math.round(n);
+
+/** `--aqt-*` value: a complete `hsl(...)`. */
+function fullHsl({ h, s, l }: Hsl): string {
+  return `hsl(${round(((h % 360) + 360) % 360)} ${round(clamp(s, 0, 100))}% ${round(clamp(l, 0, 100))}%)`;
+}
+
+/** shadcn value: a bare `H S% L%` triplet. */
+function triplet({ h, s, l }: Hsl): string {
+  return `${round(((h % 360) + 360) % 360)} ${round(clamp(s, 0, 100))}% ${round(clamp(l, 0, 100))}%`;
+}
+
+function clampBackground(hsl: Hsl, band: { min: number; max: number }): Hsl {
+  return { h: hsl.h, s: clamp(hsl.s, 0, 45), l: clamp(hsl.l, band.min, band.max) };
+}
+
+function clampAccent(hsl: Hsl): Hsl {
+  return { h: hsl.h, s: clamp(hsl.s, ACCENT_S_MIN, 95), l: clamp(hsl.l, ACCENT_L.min, ACCENT_L.max) };
+}
+
+/**
+ * Build the CSS-variable override map from workspace branding, or `null` when
+ * branding is disabled / lacks the minimum colours (→ callers fall back to the
+ * default palette).
+ *
+ * Minimum input is `brand_primary` + `brand_background`; a missing secondary
+ * falls back to primary and a missing surface is derived from the background.
+ */
+export function deriveWorkspacePalette(
+  branding: WorkspaceBranding | Workspace | null | undefined
+): CssVarMap | null {
+  if (!branding || !branding.branding_enabled) return null;
+
+  const primaryRgb = parseHex(branding.brand_primary);
+  const backgroundRgb = parseHex(branding.brand_background);
+  if (!primaryRgb || !backgroundRgb) return null;
+
+  const secondaryRgb = parseHex(branding.brand_secondary);
+  const surfaceRgb = parseHex(branding.brand_surface);
+
+  const bg = clampBackground(rgbToHsl(backgroundRgb), DARK_BG);
+  const surface = surfaceRgb
+    ? clampBackground(rgbToHsl(surfaceRgb), DARK_SURFACE)
+    : { h: bg.h, s: bg.s, l: clamp(bg.l + 2, DARK_SURFACE.min, DARK_SURFACE.max) };
+  const accent = clampAccent(rgbToHsl(primaryRgb));
+  const secondary = secondaryRgb ? clampAccent(rgbToHsl(secondaryRgb)) : accent;
+
+  // Light foreground, faintly tinted with the background hue for cohesion.
+  const fg: Hsl = { h: bg.h, s: 16, l: 96 };
+  const fgMuted: Hsl = { h: bg.h, s: 12, l: 62 };
+  const fgDim: Hsl = { h: bg.h, s: 12, l: 42 };
+  const fgFaint: Hsl = { h: bg.h, s: 12, l: 32 };
+
+  // Borders step up in lightness from the surface.
+  const border: Hsl = { h: surface.h, s: surface.s, l: clamp(surface.l + 6, 8, 24) };
+  const border2: Hsl = { h: surface.h, s: surface.s, l: clamp(surface.l + 10, 10, 28) };
+  const border3: Hsl = { h: surface.h, s: surface.s, l: clamp(surface.l + 14, 12, 32) };
+
+  const bg2: Hsl = { h: bg.h, s: bg.s, l: clamp(bg.l + 1, DARK_BG.min, DARK_BG.max + 2) };
+  const card2: Hsl = { h: surface.h, s: surface.s, l: clamp(surface.l + 1, DARK_SURFACE.min, DARK_SURFACE.max + 2) };
+  const mutedSurface: Hsl = { h: surface.h, s: surface.s, l: clamp(surface.l + 4, 8, 22) };
+
+  const onAccent = pickOnColorForeground(hslToRgb(accent));
+  const onSecondary = pickOnColorForeground(hslToRgb(secondary));
+
+  return {
+    // ── --aqt-* (full hsl) ──
+    "--aqt-bg": fullHsl(bg),
+    "--aqt-bg-2": fullHsl(bg2),
+    "--aqt-card": fullHsl(surface),
+    "--aqt-card-2": fullHsl(card2),
+    "--aqt-border": fullHsl(border),
+    "--aqt-border-2": fullHsl(border2),
+    "--aqt-border-3": fullHsl(border3),
+    "--aqt-fg": fullHsl(fg),
+    "--aqt-fg-muted": fullHsl(fgMuted),
+    "--aqt-fg-dim": fullHsl(fgDim),
+    "--aqt-fg-faint": fullHsl(fgFaint),
+    "--aqt-teal": fullHsl(accent),
+    "--aqt-violet": fullHsl(secondary),
+    // ── shadcn (bare triplet) ──
+    "--background": triplet(bg),
+    "--foreground": triplet(fg),
+    "--card": triplet(surface),
+    "--card-foreground": triplet(fg),
+    "--popover": triplet(surface),
+    "--popover-foreground": triplet(fg),
+    "--primary": triplet(accent),
+    "--primary-foreground": onAccent,
+    "--secondary": triplet(secondary),
+    "--secondary-foreground": onSecondary,
+    "--muted": triplet(mutedSurface),
+    "--muted-foreground": triplet(fgMuted),
+    "--accent": triplet(mutedSurface),
+    "--accent-foreground": triplet(fg),
+    "--border": triplet(border),
+    "--input": triplet(border),
+    "--ring": triplet(accent),
+  };
+}
+
+/** Apply a derived palette (or clear it) on an element via inline CSS vars. */
+export function applyWorkspacePalette(el: HTMLElement, palette: CssVarMap | null): void {
+  for (const name of WORKSPACE_THEME_VAR_NAMES) {
+    el.style.removeProperty(name);
+  }
+  if (palette) {
+    for (const [name, value] of Object.entries(palette)) {
+      el.style.setProperty(name, value);
+    }
+  }
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,51 +1,80 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PLATFORM_ZONE, resolveHost } from "@/lib/host";
 
-// Small in-memory TTL cache: the host->workspace map is tiny and rarely changes.
+// Small bounded TTL cache: the host->workspace map is tiny and rarely changes.
 const CACHE_TTL_MS = 60_000;
+const CACHE_MAX = 1000;
 const cache = new Map<string, { id: number | null; at: number }>();
 
-async function resolveWorkspaceId(origin: string, subdomain: string): Promise<number | null> {
+function setCache(host: string, id: number | null, at: number): void {
+  // Rough FIFO eviction: Map preserves insertion order, so the first key is oldest.
+  if (cache.size >= CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(host, { id, at });
+}
+
+type Lookup = { status: "found"; id: number } | { status: "not_found" } | { status: "error" };
+
+function fromEntry(entry: { id: number | null }): Lookup {
+  return entry.id === null ? { status: "not_found" } : { status: "found", id: entry.id };
+}
+
+async function resolveWorkspace(origin: string, subdomain: string): Promise<Lookup> {
   const host = `${subdomain}.${PLATFORM_ZONE}`;
-  const cached = cache.get(host);
   const now = Date.now();
-  if (cached && now - cached.at < CACHE_TTL_MS) return cached.id;
+  const cached = cache.get(host);
+  if (cached && now - cached.at < CACHE_TTL_MS) {
+    return fromEntry(cached);
+  }
   try {
     const res = await fetch(`${origin}/api/v1/workspaces/by-host?host=${encodeURIComponent(host)}`, {
       headers: { accept: "application/json" },
     });
-    const data = res.ok ? await res.json() : null;
-    const id = data?.workspace_id ?? null;
-    cache.set(host, { id, at: now });
-    return id;
+    if (!res.ok) {
+      // Transient backend failure: never cache it. Serve stale if we have it, else surface a 503.
+      return cached ? fromEntry(cached) : { status: "error" };
+    }
+    const data = await res.json();
+    const id = typeof data?.workspace_id === "number" ? data.workspace_id : null;
+    setCache(host, id, now);
+    return id === null ? { status: "not_found" } : { status: "found", id };
   } catch {
-    // A fetch failure (network blip, gateway restart) must never take the whole
-    // site down. Degrade to "unknown" rather than caching or throwing — the next
-    // request gets a fresh attempt instead of being stuck on a bad cache entry.
-    return null;
+    return cached ? fromEntry(cached) : { status: "error" };
   }
 }
 
 export async function middleware(request: NextRequest) {
-  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const rawHost = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const host = rawHost?.split(",")[0]?.trim() ?? null;
   const resolution = resolveHost(host);
 
   if (resolution.mode === "platform") {
     return NextResponse.next();
   }
 
-  const workspaceId = await resolveWorkspaceId(request.nextUrl.origin, resolution.subdomain);
-  if (workspaceId === null) {
+  const lookup = await resolveWorkspace(request.nextUrl.origin, resolution.subdomain);
+
+  if (lookup.status === "found") {
+    const headers = new Headers(request.headers);
+    headers.set("x-owt-workspace-id", String(lookup.id));
+    headers.set("x-owt-host-mode", "tenant");
+    return NextResponse.next({ request: { headers } });
+  }
+
+  if (lookup.status === "not_found") {
     return NextResponse.rewrite(new URL("/not-configured", request.url), { status: 404 });
   }
 
-  const headers = new Headers(request.headers);
-  headers.set("x-owt-workspace-id", String(workspaceId));
-  headers.set("x-owt-host-mode", "tenant");
-  return NextResponse.next({ request: { headers } });
+  // Transient lookup failure — do not 404 a real tenant.
+  return new NextResponse("Service temporarily unavailable", {
+    status: 503,
+    headers: { "retry-after": "5" },
+  });
 }
 
 export const config = {
-  // Skip static assets + Next internals; run on pages + API-relative routes.
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|webp|svg|ico)).*)"],
+  // Skip API route handlers, Next internals, and static assets.
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|webp|svg|ico)).*)"],
 };

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { PLATFORM_ZONE, resolveHost } from "@/lib/host";
+import { internalApiOrigin } from "@/lib/api-routes";
 
 // Small bounded TTL cache: the host->workspace map is tiny and rarely changes.
 const CACHE_TTL_MS = 60_000;
@@ -29,7 +30,8 @@ async function resolveWorkspace(origin: string, subdomain: string): Promise<Look
     return fromEntry(cached);
   }
   try {
-    const res = await fetch(`${origin}/api/v1/workspaces/by-host?host=${encodeURIComponent(host)}`, {
+    const base = internalApiOrigin() ?? origin;
+    const res = await fetch(`${base}/api/v1/workspaces/by-host?host=${encodeURIComponent(host)}`, {
       headers: { accept: "application/json" },
     });
     if (!res.ok) {
@@ -51,13 +53,23 @@ export async function middleware(request: NextRequest) {
   const resolution = resolveHost(host);
 
   if (resolution.mode === "platform") {
-    return NextResponse.next();
+    // Defense-in-depth: strip any client-supplied workspace-scoping headers
+    // before letting the request through, so a caller can never spoof SSR
+    // workspace scope or white-label chrome on the platform (apex/www) host.
+    const headers = new Headers(request.headers);
+    headers.delete("x-owt-workspace-id");
+    headers.delete("x-owt-host-mode");
+    return NextResponse.next({ request: { headers } });
   }
 
   const lookup = await resolveWorkspace(request.nextUrl.origin, resolution.subdomain);
 
   if (lookup.status === "found") {
     const headers = new Headers(request.headers);
+    // Delete before set so a client-supplied value can never survive even
+    // if the set logic below changes.
+    headers.delete("x-owt-workspace-id");
+    headers.delete("x-owt-host-mode");
     headers.set("x-owt-workspace-id", String(lookup.id));
     headers.set("x-owt-host-mode", "tenant");
     return NextResponse.next({ request: { headers } });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PLATFORM_ZONE, resolveHost } from "@/lib/host";
+
+// Small in-memory TTL cache: the host->workspace map is tiny and rarely changes.
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, { id: number | null; at: number }>();
+
+async function resolveWorkspaceId(origin: string, subdomain: string): Promise<number | null> {
+  const host = `${subdomain}.${PLATFORM_ZONE}`;
+  const cached = cache.get(host);
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) return cached.id;
+  try {
+    const res = await fetch(`${origin}/api/v1/workspaces/by-host?host=${encodeURIComponent(host)}`, {
+      headers: { accept: "application/json" },
+    });
+    const data = res.ok ? await res.json() : null;
+    const id = data?.workspace_id ?? null;
+    cache.set(host, { id, at: now });
+    return id;
+  } catch {
+    // A fetch failure (network blip, gateway restart) must never take the whole
+    // site down. Degrade to "unknown" rather than caching or throwing — the next
+    // request gets a fresh attempt instead of being stuck on a bad cache entry.
+    return null;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  const resolution = resolveHost(host);
+
+  if (resolution.mode === "platform") {
+    return NextResponse.next();
+  }
+
+  const workspaceId = await resolveWorkspaceId(request.nextUrl.origin, resolution.subdomain);
+  if (workspaceId === null) {
+    return NextResponse.rewrite(new URL("/not-configured", request.url), { status: 404 });
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("x-owt-workspace-id", String(workspaceId));
+  headers.set("x-owt-host-mode", "tenant");
+  return NextResponse.next({ request: { headers } });
+}
+
+export const config = {
+  // Skip static assets + Next internals; run on pages + API-relative routes.
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|webp|svg|ico)).*)"],
+};

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -9,12 +9,37 @@ type OAuthUrlResponse = {
 
 type ForwardedAuthHeaders = Record<string, string>;
 
+type OAuthAction = "login" | "link";
+
 type OAuthUrlParams = {
   origin: string;
   redirect: string;
-  action: "login" | "link";
+  action: OAuthAction;
   csrf: string;
 };
+
+// Returned by POST /api/auth/oauth/{provider}/callback. `origin`/`redirect`/
+// `action` are decoded server-side from the signed OAuth state (Task 9) so the
+// callback can redirect back to whichever subdomain started the flow.
+export interface OAuthCallbackResult {
+  access_token: string;
+  refresh_token: string;
+  origin: string;
+  redirect: string;
+  action: OAuthAction;
+}
+
+// Returned by POST /api/auth/oauth/{provider}/link — same origin/redirect/action
+// echo as OAuthCallbackResult, "for symmetry" (Task 9), so the link redirect can
+// also honor the origin the flow started on.
+export interface OAuthLinkResult {
+  message: string;
+  provider: string;
+  username: string;
+  origin: string;
+  redirect: string;
+  action: OAuthAction;
+}
 
 export const authService = {
   async getOAuthUrl(provider: OAuthProviderName, params: OAuthUrlParams): Promise<OAuthUrlResponse> {
@@ -33,15 +58,22 @@ export const authService = {
     return res.json();
   },
 
+  // `csrf` is the RAW value of the `owt_oauth_csrf` cookie (never the hash) —
+  // the backend re-hashes it and fail-closed-compares against the value bound
+  // into the signed state at `getOAuthUrl` time. Sent in the body (alongside
+  // code/state) rather than as a query param so the gateway's generic
+  // body-merge forwarding (`bodyWithMeta`) carries it through unmodified.
   async exchangeOAuthCode(
     provider: OAuthProviderName,
     code: string,
     state: string,
+    csrf: string,
     headers?: ForwardedAuthHeaders,
-  ): Promise<TokenPair> {
+  ): Promise<OAuthCallbackResult> {
     const res = await apiFetch(`/api/auth/oauth/${provider}/callback`, {
-      query: { code, state },
+      method: "POST",
       headers,
+      body: { code, state, csrf },
       throwOnError: false
     });
     if (!res.ok) throw new Error(`Failed to complete ${provider} OAuth`);
@@ -53,19 +85,21 @@ export const authService = {
     code: string,
     state: string,
     accessToken: string,
+    csrf: string,
     headers?: ForwardedAuthHeaders,
-  ): Promise<void> {
+  ): Promise<OAuthLinkResult> {
     const res = await apiFetch(`/api/auth/oauth/${provider}/link`, {
       method: "POST",
       token: accessToken,
       headers,
-      body: { code, state },
+      body: { code, state, csrf },
       throwOnError: false
     });
 
     if (!res.ok) {
       throw new Error(`Failed to link ${provider} OAuth account`);
     }
+    return res.json();
   },
 
   async me(accessToken?: string): Promise<AuthUser> {

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -9,9 +9,20 @@ type OAuthUrlResponse = {
 
 type ForwardedAuthHeaders = Record<string, string>;
 
+type OAuthUrlParams = {
+  origin: string;
+  redirect: string;
+  action: "login" | "link";
+  csrf: string;
+};
+
 export const authService = {
-  async getOAuthUrl(provider: OAuthProviderName): Promise<OAuthUrlResponse> {
-    const res = await apiFetch(`/api/auth/oauth/${provider}/url`, { throwOnError: false });
+  async getOAuthUrl(provider: OAuthProviderName, params: OAuthUrlParams): Promise<OAuthUrlResponse> {
+    const res = await apiFetch(`/api/auth/oauth/${provider}/url`, {
+      query: { origin: params.origin, redirect: params.redirect, action: params.action, csrf: params.csrf },
+      skipWorkspace: true,
+      throwOnError: false
+    });
     if (!res.ok) throw new Error(`Failed to get ${provider} OAuth URL`);
     return res.json();
   },

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -31,11 +31,23 @@ import { apiFetch } from "@/lib/api-fetch";
 const USER_TTL_SECONDS = 300;
 
 export default class userService {
-  static async getAll(params: SearchPaginationParams): Promise<PaginatedResponse<User>> {
+  /**
+   * `options.workspaceId`, when provided (even as `null`), pins the request to
+   * that workspace explicitly instead of resolving it from ambient request
+   * headers/cookies. Required for callers running inside `unstable_cache`
+   * (e.g. the sitemap), where Next.js forbids calling `headers()`/`cookies()`.
+   */
+  static async getAll(
+    params: SearchPaginationParams,
+    options?: { workspaceId?: string | number | null }
+  ): Promise<PaginatedResponse<User>> {
+    const hasWorkspaceOverride = options !== undefined;
     return apiFetch("/api/v1/users", {
       query: {
-        ...params
-      }
+        ...params,
+        workspace_id: hasWorkspaceOverride ? options?.workspaceId ?? undefined : undefined
+      },
+      skipWorkspace: hasWorkspaceOverride
     }).then((res) => res.json());
   }
   static async getUserByName(name: string): Promise<User> {

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -47,7 +47,11 @@ export default class userService {
         ...params,
         workspace_id: hasWorkspaceOverride ? options?.workspaceId ?? undefined : undefined
       },
-      skipWorkspace: hasWorkspaceOverride
+      // Explicit workspace override == "no ambient request state" (unstable_cache
+      // caller, e.g. sitemap): skip both the workspace-header and access-cookie
+      // reads so no dynamic API is called inside the cache boundary.
+      skipWorkspace: hasWorkspaceOverride,
+      skipAuth: hasWorkspaceOverride
     }).then((res) => res.json());
   }
   static async getUserByName(name: string): Promise<User> {

--- a/frontend/src/services/workspace.service.ts
+++ b/frontend/src/services/workspace.service.ts
@@ -17,6 +17,15 @@ export default class workspaceService {
     return apiFetch("/api/v1/workspaces").then((r) => r.json());
   }
 
+  /** Resolve a platform-zone host to its workspace (used by middleware/host resolution). */
+  static async getByHost(host: string): Promise<{ workspace_id: number; slug: string } | null> {
+    const res = await apiFetch(`/api/v1/workspaces/by-host`, {
+      query: { host },
+      skipWorkspace: true,
+    });
+    return res.json();
+  }
+
   static async getById(id: number): Promise<Workspace> {
     return apiFetch(`/api/v1/workspaces/${id}`).then((r) => r.json());
   }

--- a/frontend/src/services/workspace.service.ts
+++ b/frontend/src/services/workspace.service.ts
@@ -40,6 +40,11 @@ export default class workspaceService {
       description?: string;
       icon_url?: string | null;
       is_active?: boolean;
+      branding_enabled?: boolean;
+      brand_primary?: string | null;
+      brand_secondary?: string | null;
+      brand_background?: string | null;
+      brand_surface?: string | null;
       default_division_grid_version_id?: number | null;
     }
   ): Promise<Workspace> {

--- a/frontend/src/services/workspace.service.ts
+++ b/frontend/src/services/workspace.service.ts
@@ -17,15 +17,6 @@ export default class workspaceService {
     return apiFetch("/api/v1/workspaces").then((r) => r.json());
   }
 
-  /** Resolve a platform-zone host to its workspace (used by middleware/host resolution). */
-  static async getByHost(host: string): Promise<{ workspace_id: number; slug: string } | null> {
-    const res = await apiFetch(`/api/v1/workspaces/by-host`, {
-      query: { host },
-      skipWorkspace: true,
-    });
-    return res.json();
-  }
-
   static async getById(id: number): Promise<Workspace> {
     return apiFetch(`/api/v1/workspaces/${id}`).then((r) => r.json());
   }

--- a/frontend/src/services/workspace.service.ts
+++ b/frontend/src/services/workspace.service.ts
@@ -54,6 +54,9 @@ export default class workspaceService {
       brand_secondary?: string | null;
       brand_background?: string | null;
       brand_surface?: string | null;
+      subdomain?: string | null;
+      seo_title?: string | null;
+      seo_description?: string | null;
       default_division_grid_version_id?: number | null;
     }
   ): Promise<Workspace> {

--- a/frontend/src/stores/auth-profile.store.ts
+++ b/frontend/src/stores/auth-profile.store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { getTokenFromCookies, refreshAccessToken } from "@/lib/auth-tokens";
+import { getAccessTokenCookie, refreshAccessToken } from "@/lib/auth-tokens";
 
 export type WorkspaceRbac = {
   workspace_id: number;
@@ -79,7 +79,7 @@ export const useAuthProfileStore = create<AuthProfileState>((set, get) => ({
     }
 
     try {
-      const token = await getTokenFromCookies("aqt_access_token");
+      const token = await getAccessTokenCookie();
       let res = await fetch("/api/auth/me", {
         method: "GET",
         headers: token ? { Authorization: `Bearer ${token}` } : {},

--- a/frontend/src/stores/workspace.store.test.ts
+++ b/frontend/src/stores/workspace.store.test.ts
@@ -4,6 +4,7 @@ import type { AuthProfile } from "@/stores/auth-profile.store";
 import {
   filterAccessibleWorkspaces,
   resolveCurrentWorkspaceId,
+  useWorkspaceStore,
 } from "@/stores/workspace.store";
 import type { Workspace } from "@/types/workspace.types";
 
@@ -56,5 +57,26 @@ describe("workspace store helpers", () => {
     const accessible = [createWorkspace(5), createWorkspace(8)];
 
     expect(resolveCurrentWorkspaceId(accessible, 99)).toBe(5);
+  });
+});
+
+describe("workspace store host lock (tenant white-label)", () => {
+  it("setHostLock forces the current workspace and blocks switching", () => {
+    // Start clean.
+    useWorkspaceStore.getState().setHostLock(null);
+    useWorkspaceStore.setState({ currentWorkspaceId: 2 });
+
+    // Locking a tenant host overrides the current (cookie-derived) workspace.
+    useWorkspaceStore.getState().setHostLock(7);
+    expect(useWorkspaceStore.getState().hostLockedWorkspaceId).toBe(7);
+    expect(useWorkspaceStore.getState().currentWorkspaceId).toBe(7);
+
+    // While locked, switching is ignored (guard returns before any cookie write).
+    useWorkspaceStore.getState().setCurrentWorkspace(9);
+    expect(useWorkspaceStore.getState().currentWorkspaceId).toBe(7);
+
+    // Clearing the lock (apex) drops the lock flag.
+    useWorkspaceStore.getState().setHostLock(null);
+    expect(useWorkspaceStore.getState().hostLockedWorkspaceId).toBeNull();
   });
 });

--- a/frontend/src/stores/workspace.store.ts
+++ b/frontend/src/stores/workspace.store.ts
@@ -18,10 +18,19 @@ const WORKSPACE_COOKIE_TTL_DAYS = 365;
 type WorkspaceState = {
   workspaces: Workspace[];
   currentWorkspaceId: number | null;
+  /**
+   * On a tenant (white-label) host the workspace is fixed by the request host,
+   * not the cookie/store. When set, the store scope is locked to this id so
+   * client-side `apiFetch` and the theme sync match the server-side host lock,
+   * switching is disabled, and the workspace cookie is left untouched. `null`
+   * on the apex/platform host.
+   */
+  hostLockedWorkspaceId: number | null;
   isLoading: boolean;
 
   fetchWorkspaces: () => Promise<void>;
   setCurrentWorkspace: (id: number) => void;
+  setHostLock: (id: number | null) => void;
   getCurrentWorkspace: () => Workspace | undefined;
 };
 
@@ -62,6 +71,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     (set, get) => ({
       workspaces: [],
       currentWorkspaceId: null,
+      hostLockedWorkspaceId: null,
       isLoading: false,
 
       fetchWorkspaces: async () => {
@@ -69,15 +79,20 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         set({ isLoading: true });
         try {
           const workspaces = await workspaceService.getAll();
+          const locked = get().hostLockedWorkspaceId;
           const current = get().currentWorkspaceId;
-          const nextId = resolveCurrentWorkspaceId(workspaces, current);
-          if (nextId !== null) {
-            Cookies.set(WORKSPACE_COOKIE, String(nextId), {
-              sameSite: "lax",
-              expires: WORKSPACE_COOKIE_TTL_DAYS
-            });
-          } else {
-            Cookies.remove(WORKSPACE_COOKIE);
+          const nextId = locked ?? resolveCurrentWorkspaceId(workspaces, current);
+          // On a locked tenant host the scope comes from the request host, not
+          // the cookie — never touch the workspace cookie there.
+          if (locked == null) {
+            if (nextId !== null) {
+              Cookies.set(WORKSPACE_COOKIE, String(nextId), {
+                sameSite: "lax",
+                expires: WORKSPACE_COOKIE_TTL_DAYS
+              });
+            } else {
+              Cookies.remove(WORKSPACE_COOKIE);
+            }
           }
           set({
             workspaces,
@@ -90,11 +105,25 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       },
 
       setCurrentWorkspace: (id: number) => {
+        // On a locked tenant (white-label) host the workspace is fixed by the
+        // request host; ignore attempts to switch.
+        if (get().hostLockedWorkspaceId != null) return;
         Cookies.set(WORKSPACE_COOKIE, String(id), {
           sameSite: "lax",
           expires: WORKSPACE_COOKIE_TTL_DAYS
         });
         set({ currentWorkspaceId: id });
+      },
+
+      setHostLock: (id: number | null) => {
+        // Lock (tenant host) or clear (apex) the client-side workspace scope.
+        // Forcing currentWorkspaceId corrects it even if fetchWorkspaces ran
+        // first, so client apiFetch/theme-sync align with the SSR host lock.
+        if (id != null) {
+          set({ hostLockedWorkspaceId: id, currentWorkspaceId: id });
+        } else {
+          set({ hostLockedWorkspaceId: null });
+        }
       },
 
       getCurrentWorkspace: () => {

--- a/frontend/src/stores/workspace.store.ts
+++ b/frontend/src/stores/workspace.store.ts
@@ -120,6 +120,10 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         // Forcing currentWorkspaceId corrects it even if fetchWorkspaces ran
         // first, so client apiFetch/theme-sync align with the SSR host lock.
         if (id != null) {
+          // Also drop any workspace cookie a race-ahead fetchWorkspaces may have
+          // written, so the "no cookie on a locked host" invariant holds
+          // regardless of effect order (SSR scopes by the host header anyway).
+          Cookies.remove(WORKSPACE_COOKIE);
           set({ hostLockedWorkspaceId: id, currentWorkspaceId: id });
         } else {
           set({ hostLockedWorkspaceId: null });

--- a/frontend/src/stores/workspace.store.ts
+++ b/frontend/src/stores/workspace.store.ts
@@ -5,7 +5,11 @@ import type { AuthProfile } from "@/stores/auth-profile.store";
 import { Workspace } from "@/types/workspace.types";
 import workspaceService from "@/services/workspace.service";
 
-const WORKSPACE_COOKIE = "aqt-workspace-id";
+// Canonical workspace cookie name. LEGACY_WORKSPACE_COOKIE is read as a
+// fallback during the aqt->owt rename so an active workspace selection is
+// not lost; it is never written.
+export const WORKSPACE_COOKIE = "owt-workspace-id";
+export const LEGACY_WORKSPACE_COOKIE = "aqt-workspace-id";
 // Persist for a year so the active workspace survives browser restarts and is
 // present on the very first server render of each new session — otherwise SSR
 // reads no workspace and server components render unscoped (cross-workspace) data.

--- a/frontend/src/types/workspace.types.ts
+++ b/frontend/src/types/workspace.types.ts
@@ -118,8 +118,23 @@ export interface Workspace {
   description: string | null;
   icon_url: string | null;
   is_active: boolean;
+  /** Per-workspace main-site branding (see lib/workspace-theme). */
+  branding_enabled: boolean;
+  brand_primary: string | null;
+  brand_secondary: string | null;
+  brand_background: string | null;
+  brand_surface: string | null;
   default_division_grid_version_id: number | null;
   default_division_grid_version: DivisionGridVersion | null;
+}
+
+/** The 4 organiser-controlled brand colours + master toggle. */
+export interface WorkspaceBranding {
+  branding_enabled: boolean;
+  brand_primary: string | null;
+  brand_secondary: string | null;
+  brand_background: string | null;
+  brand_surface: string | null;
 }
 
 export type WorkspaceSystemRole = "owner" | "admin" | "member" | "player";

--- a/frontend/src/types/workspace.types.ts
+++ b/frontend/src/types/workspace.types.ts
@@ -124,6 +124,9 @@ export interface Workspace {
   brand_secondary: string | null;
   brand_background: string | null;
   brand_surface: string | null;
+  subdomain: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
   default_division_grid_version_id: number | null;
   default_division_grid_version: DivisionGridVersion | null;
 }

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -174,7 +174,6 @@ func run() error {
 	mux.HandleFunc("GET /api/auth/oauth/providers", identityHandler.OAuthProviders)
 	mux.HandleFunc("GET /api/auth/oauth/connections", identityHandler.OAuthConnections)
 	mux.HandleFunc("GET /api/auth/oauth/{provider}/url", identityHandler.OAuthURL)
-	mux.HandleFunc("GET /api/auth/oauth/{provider}/callback", authLimiter.Wrap(identityHandler.OAuthCallbackGet))
 	mux.HandleFunc("POST /api/auth/oauth/{provider}/callback", authLimiter.Wrap(identityHandler.OAuthCallbackPost))
 	mux.HandleFunc("POST /api/auth/oauth/{provider}/link", identityHandler.OAuthLink)
 	mux.HandleFunc("DELETE /api/auth/oauth/{provider}/unlink", identityHandler.OAuthUnlink)

--- a/gateway/internal/app/routes.go
+++ b/gateway/internal/app/routes.go
@@ -40,6 +40,7 @@ var ReadRoutes = []edge.RouteSpec{
 	{Method: "GET", Pattern: "/api/v1/statistics/won-maps", Queue: "rpc.app.statistics.won_maps", AllQuery: true, Auth: edge.AuthNone},
 	// --- workspaces (public reads; writes + members in Phase 2) -------------
 	{Method: "GET", Pattern: "/api/v1/workspaces", Queue: "rpc.app.workspaces.list", Auth: edge.AuthNone},
+	{Method: "GET", Pattern: "/api/v1/workspaces/by-host", Queue: "rpc.app.workspaces.by_host", Query: []string{"host"}, Auth: edge.AuthNone},
 	{Method: "GET", Pattern: "/api/v1/workspaces/{id}", Queue: "rpc.app.workspaces.get", IDParam: "id", Auth: edge.AuthNone},
 	// --- users (literals + /{id}/... + bare /{name} last) -------------------
 	{Method: "GET", Pattern: "/api/v1/users", Queue: "rpc.app.users.list", AllQuery: true, Auth: edge.AuthNone},

--- a/gateway/internal/auth/auth.go
+++ b/gateway/internal/auth/auth.go
@@ -17,8 +17,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// CookieName is where the frontend stores the access token.
-const CookieName = "aqt_access_token"
+// CookieName is the canonical access-token cookie; LegacyCookieName is read as a
+// fallback during the aqt->owt rename so existing sessions are not logged out.
+const CookieName = "owt_access_token"
+const LegacyCookieName = "aqt_access_token"
 
 // User is an authenticated WebSocket/HTTP principal. A nil *User means anonymous.
 type User struct {
@@ -100,8 +102,10 @@ func extractToken(r *http.Request) string {
 		}
 	}
 
-	if c, err := r.Cookie(CookieName); err == nil && c.Value != "" {
-		return strings.TrimSpace(strings.TrimPrefix(c.Value, "Bearer "))
+	for _, name := range []string{CookieName, LegacyCookieName} {
+		if c, err := r.Cookie(name); err == nil && c.Value != "" {
+			return strings.TrimSpace(strings.TrimPrefix(c.Value, "Bearer "))
+		}
 	}
 	return ""
 }

--- a/gateway/internal/auth/auth_cookie_test.go
+++ b/gateway/internal/auth/auth_cookie_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestExtractTokenPrefersOwtThenAqtCookie(t *testing.T) {
+	cases := []struct {
+		name    string
+		cookies []*http.Cookie
+		want    string
+	}{
+		{"owt only", []*http.Cookie{{Name: "owt_access_token", Value: "N"}}, "N"},
+		{"aqt fallback", []*http.Cookie{{Name: "aqt_access_token", Value: "O"}}, "O"},
+		{"owt wins", []*http.Cookie{{Name: "aqt_access_token", Value: "O"}, {Name: "owt_access_token", Value: "N"}}, "N"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "/", nil)
+			for _, ck := range c.cookies {
+				r.AddCookie(ck)
+			}
+			if got := extractToken(r); got != c.want {
+				t.Fatalf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -23,6 +23,12 @@ import (
 // itself must never leave production open.
 const defaultWSAllowedOrigins = "https://owt.craazzzyyfoxx.me,https://*.owt.craazzzyyfoxx.me"
 
+// DefaultWSAllowedOrigins is the parsed form of defaultWSAllowedOrigins,
+// exported so callers outside this package (e.g. ws package tests) can
+// assert against the exact production default without duplicating the
+// literal and risking drift.
+var DefaultWSAllowedOrigins = splitCSV(defaultWSAllowedOrigins)
+
 // Config holds all runtime settings for the gateway.
 type Config struct {
 	Port             string

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -14,6 +14,15 @@ import (
 	"time"
 )
 
+// defaultWSAllowedOrigins is the fallback for GATEWAY_WS_ALLOWED_ORIGINS. It
+// covers the platform apex plus every tenant subdomain (workspace white-label
+// hosts, see docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md)
+// so that ws.NewHandler never receives an empty allow-list in a default
+// deployment and falls back to AcceptOptions.InsecureSkipVerify. Operators can
+// still override this with an explicit (possibly empty) CSV, but the default
+// itself must never leave production open.
+const defaultWSAllowedOrigins = "https://owt.craazzzyyfoxx.me,https://*.owt.craazzzyyfoxx.me"
+
 // Config holds all runtime settings for the gateway.
 type Config struct {
 	Port             string
@@ -127,7 +136,7 @@ func Load() (*Config, error) {
 		DBPgBouncer:      getenvBool("DB_PGBOUNCER", false),
 		WSIdleTimeout:    time.Duration(getenvInt("WS_IDLE_TIMEOUT", 60)) * time.Second,
 		WSReplayLimit:    getenvInt("WS_REPLAY_LIMIT", 500),
-		WSAllowedOrigins: splitCSV(os.Getenv("GATEWAY_WS_ALLOWED_ORIGINS")),
+		WSAllowedOrigins: splitCSV(getenv("GATEWAY_WS_ALLOWED_ORIGINS", defaultWSAllowedOrigins)),
 		AuthRateLimit:    getenvInt("GATEWAY_AUTH_RATE_LIMIT", 10),
 		AuthRateWindow:   time.Duration(getenvInt("GATEWAY_AUTH_RATE_WINDOW", 60)) * time.Second,
 		Upstreams: Upstreams{

--- a/gateway/internal/config/config_test.go
+++ b/gateway/internal/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+// clearGatewayEnv removes every env var Load reads so tests start from a
+// clean slate and don't inherit values from the shell running `go test`.
+func clearGatewayEnv(t *testing.T) {
+	t.Helper()
+	keys := []string{
+		"JWT_SECRET_KEY", "GATEWAY_DATABASE_URL", "GATEWAY_ENV", "SENTRY_ENVIRONMENT",
+		"RABBITMQ_URL", "GATEWAY_WS_ALLOWED_ORIGINS",
+	}
+	for _, k := range keys {
+		v, ok := os.LookupEnv(k)
+		os.Unsetenv(k)
+		if ok {
+			t.Cleanup(func(k, v string) func() {
+				return func() { os.Setenv(k, v) }
+			}(k, v))
+		}
+	}
+}
+
+func TestLoad_WSAllowedOriginsDefault(t *testing.T) {
+	clearGatewayEnv(t)
+	os.Setenv("JWT_SECRET_KEY", "12345678901234567890123456789012")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := []string{"https://owt.craazzzyyfoxx.me", "https://*.owt.craazzzyyfoxx.me"}
+	if !reflect.DeepEqual(cfg.WSAllowedOrigins, want) {
+		t.Fatalf("WSAllowedOrigins = %v, want %v", cfg.WSAllowedOrigins, want)
+	}
+}
+
+func TestLoad_WSAllowedOriginsOverride(t *testing.T) {
+	clearGatewayEnv(t)
+	os.Setenv("JWT_SECRET_KEY", "12345678901234567890123456789012")
+	os.Setenv("GATEWAY_WS_ALLOWED_ORIGINS", "https://custom.example.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := []string{"https://custom.example.com"}
+	if !reflect.DeepEqual(cfg.WSAllowedOrigins, want) {
+		t.Fatalf("WSAllowedOrigins = %v, want %v", cfg.WSAllowedOrigins, want)
+	}
+}

--- a/gateway/internal/identity/docroutes.go
+++ b/gateway/internal/identity/docroutes.go
@@ -33,7 +33,6 @@ var PublicDocRoutes = []edge.RouteSpec{
 	{Method: "GET", Pattern: "/api/auth/oauth/providers", Queue: "rpc.identity.oauth_providers", Auth: edge.AuthNone},
 	{Method: "GET", Pattern: "/api/auth/oauth/connections", Queue: "rpc.identity.oauth_connections", Auth: edge.AuthRequired},
 	{Method: "GET", Pattern: "/api/auth/oauth/{provider}/url", Queue: "rpc.identity.oauth_url", Auth: edge.AuthOptional},
-	{Method: "GET", Pattern: "/api/auth/oauth/{provider}/callback", Queue: "rpc.identity.oauth_callback", Auth: edge.AuthNone},
 	{Method: "POST", Pattern: "/api/auth/oauth/{provider}/callback", Queue: "rpc.identity.oauth_callback", Body: true, Auth: edge.AuthNone},
 	{Method: "POST", Pattern: "/api/auth/oauth/{provider}/link", Queue: "rpc.identity.oauth_link", Body: true, Auth: edge.AuthRequired},
 	{Method: "DELETE", Pattern: "/api/auth/oauth/{provider}/unlink", Queue: "rpc.identity.oauth_unlink", Auth: edge.AuthRequired, Success: 204},

--- a/gateway/internal/identity/handler.go
+++ b/gateway/internal/identity/handler.go
@@ -244,9 +244,19 @@ func (h *Handler) OAuthProviders(w http.ResponseWriter, r *http.Request) {
 	h.callIdentity(w, r, queueOAuthProviders, []byte("{}"), http.StatusOK)
 }
 
-// OAuthURL mirrors GET /oauth/{provider}/url.
+// OAuthURL mirrors GET /oauth/{provider}/url?origin=&redirect=&action=&csrf=.
+// origin/redirect/action/csrf get signed into the OAuth state server-side
+// (identity-service oauth_flows.get_url) so the callback can later redirect
+// back to the originating host and bind the browser via the csrf cookie.
 func (h *Handler) OAuthURL(w http.ResponseWriter, r *http.Request) {
-	body, _ := json.Marshal(map[string]any{"provider": r.PathValue("provider")})
+	q := r.URL.Query()
+	body, _ := json.Marshal(map[string]any{
+		"provider": r.PathValue("provider"),
+		"origin":   q.Get("origin"),
+		"redirect": q.Get("redirect"),
+		"action":   q.Get("action"),
+		"csrf":     q.Get("csrf"),
+	})
 	h.callIdentity(w, r, queueOAuthURL, body, http.StatusOK)
 }
 

--- a/gateway/internal/identity/handler.go
+++ b/gateway/internal/identity/handler.go
@@ -260,19 +260,6 @@ func (h *Handler) OAuthURL(w http.ResponseWriter, r *http.Request) {
 	h.callIdentity(w, r, queueOAuthURL, body, http.StatusOK)
 }
 
-// OAuthCallbackGet mirrors GET /oauth/{provider}/callback?code=&state= -> Token.
-func (h *Handler) OAuthCallbackGet(w http.ResponseWriter, r *http.Request) {
-	ua, ip := clientMeta(r)
-	body, _ := json.Marshal(map[string]any{
-		"provider":   r.PathValue("provider"),
-		"code":       r.URL.Query().Get("code"),
-		"state":      r.URL.Query().Get("state"),
-		"user_agent": ua,
-		"ip_address": ip,
-	})
-	h.callIdentity(w, r, queueOAuthCallback, body, http.StatusOK)
-}
-
 // OAuthCallbackPost mirrors POST /oauth/{provider}/callback (body code+state) -> Token.
 func (h *Handler) OAuthCallbackPost(w http.ResponseWriter, r *http.Request) {
 	body, ok := bodyWithMeta(w, r, map[string]any{"provider": r.PathValue("provider")})

--- a/gateway/internal/openapi/openapi.go
+++ b/gateway/internal/openapi/openapi.go
@@ -345,7 +345,7 @@ func (b *builder) components() map[string]any {
 				"type":         "http",
 				"scheme":       "bearer",
 				"bearerFormat": "JWT",
-				"description":  "JWT access token. Also accepted via the `aqt_access_token` cookie or a `?token=Bearer <jwt>` query parameter.",
+				"description":  "JWT access token. Also accepted via the `owt_access_token` cookie (legacy `aqt_access_token` still read as a fallback) or a `?token=Bearer <jwt>` query parameter.",
 			},
 		},
 		"schemas": schemas,

--- a/gateway/internal/ws/handler.go
+++ b/gateway/internal/ws/handler.go
@@ -41,28 +41,30 @@ type Handler struct {
 
 // NewHandler wires the WebSocket handler. recordActive may be nil; when set it
 // is called with the user ID of each authenticated connection so WS users count
-// toward the active-user metrics. allowedOrigins, when non-empty, enforces the
-// browser Origin against that allowlist (CSWSH protection); when empty the
-// previous permissive behaviour is kept (see accept setup below).
+// toward the active-user metrics. allowedOrigins enforces the browser Origin
+// against that allowlist (CSWSH protection); InsecureSkipVerify is never set.
 //
 // config.Load defaults GATEWAY_WS_ALLOWED_ORIGINS to the platform apex plus
 // the "*.owt.craazzzyyfoxx.me" wildcard (coder/websocket's OriginPatterns
 // supports "*" globs, so this also covers every tenant subdomain), so a
-// default deployment always takes the allowlist branch below. The
-// InsecureSkipVerify fallback only fires if an operator explicitly overrides
-// GATEWAY_WS_ALLOWED_ORIGINS to an empty value — it must never be relied on
-// in production.
+// default deployment always has a non-empty allowlist. If an operator
+// explicitly overrides GATEWAY_WS_ALLOWED_ORIGINS to an empty value, we do
+// NOT fall back to InsecureSkipVerify: coder/websocket's Accept always
+// authorizes the request's own Host regardless of OriginPatterns (see
+// authenticateOrigin in its accept.go), so an empty allowlist degrades to
+// same-origin-only enforcement rather than "accept any origin". That keeps a
+// same-host WS connection (e.g. a tenant subdomain talking to itself)
+// working while still rejecting foreign cross-site handshakes.
 func NewHandler(hub *Hub, a *auth.Authenticator, authz Authorizer, rep Replayer, idleTimeout time.Duration, log *slog.Logger, allowedOrigins []string, recordActive func(userID int64)) *Handler {
-	accept := &websocket.AcceptOptions{}
-	if len(allowedOrigins) > 0 {
+	if len(allowedOrigins) == 0 {
+		log.Warn("GATEWAY_WS_ALLOWED_ORIGINS is empty; WebSocket origin checking is degraded to same-origin-only")
+	}
+	accept := &websocket.AcceptOptions{
 		// Enforce the Origin header against the configured allowlist so a hostile
-		// page cannot open an authenticated cross-site WebSocket (CSWSH).
-		accept.OriginPatterns = allowedOrigins
-	} else {
-		// No allowlist configured: preserve the previous behaviour (the gateway
-		// runs behind nginx and is not exposed directly to untrusted browsers).
-		// Set GATEWAY_WS_ALLOWED_ORIGINS to the frontend domain(s) to tighten this.
-		accept.InsecureSkipVerify = true
+		// page cannot open an authenticated cross-site WebSocket (CSWSH). Never
+		// set InsecureSkipVerify: an empty allowedOrigins still fails closed to
+		// same-origin (see the doc comment above), never open.
+		OriginPatterns: allowedOrigins,
 	}
 	return &Handler{
 		hub:          hub,

--- a/gateway/internal/ws/handler.go
+++ b/gateway/internal/ws/handler.go
@@ -44,6 +44,14 @@ type Handler struct {
 // toward the active-user metrics. allowedOrigins, when non-empty, enforces the
 // browser Origin against that allowlist (CSWSH protection); when empty the
 // previous permissive behaviour is kept (see accept setup below).
+//
+// config.Load defaults GATEWAY_WS_ALLOWED_ORIGINS to the platform apex plus
+// the "*.owt.craazzzyyfoxx.me" wildcard (coder/websocket's OriginPatterns
+// supports "*" globs, so this also covers every tenant subdomain), so a
+// default deployment always takes the allowlist branch below. The
+// InsecureSkipVerify fallback only fires if an operator explicitly overrides
+// GATEWAY_WS_ALLOWED_ORIGINS to an empty value — it must never be relied on
+// in production.
 func NewHandler(hub *Hub, a *auth.Authenticator, authz Authorizer, rep Replayer, idleTimeout time.Duration, log *slog.Logger, allowedOrigins []string, recordActive func(userID int64)) *Handler {
 	accept := &websocket.AcceptOptions{}
 	if len(allowedOrigins) > 0 {

--- a/gateway/internal/ws/origin_test.go
+++ b/gateway/internal/ws/origin_test.go
@@ -1,0 +1,97 @@
+package ws
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/CraazzzyyFoxx/anak-tournaments/gateway/internal/auth"
+)
+
+// productionWSAllowedOrigins mirrors config.defaultWSAllowedOrigins (gateway/
+// internal/config/config.go). It is duplicated here, rather than imported,
+// to keep this package free of a config dependency; TestLoad_WSAllowedOriginsDefault
+// in internal/config guards the source of truth.
+var productionWSAllowedOrigins = []string{
+	"https://owt.craazzzyyfoxx.me",
+	"https://*.owt.craazzzyyfoxx.me",
+}
+
+// dialWithOrigin attempts the WS handshake against srvURL with the given
+// Origin header and reports whether the server accepted the connection.
+func dialWithOrigin(t *testing.T, srvURL, origin string) error {
+	t.Helper()
+	u := "ws" + srvURL[len("http"):] + "/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	header := http.Header{}
+	if origin != "" {
+		header.Set("Origin", origin)
+	}
+	c, _, err := websocket.Dial(ctx, u, &websocket.DialOptions{HTTPHeader: header})
+	if err == nil {
+		c.CloseNow()
+	}
+	return err
+}
+
+// TestWS_OriginAllowlist_ProductionDefault exercises the real coder/websocket
+// accept path (not just config parsing) with the same allowlist
+// config.Load's default produces, so a regression in either the default
+// value or how it's wired into ws.NewHandler's AcceptOptions fails this test.
+func TestWS_OriginAllowlist_ProductionDefault(t *testing.T) {
+	h := NewHandler(NewHub(), auth.New(wsSecret), allowAuthorizer{allow: true}, fakeReplayer{},
+		30*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)), productionWSAllowedOrigins, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/ws", h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		name      string
+		origin    string
+		wantAllow bool
+	}{
+		{"no origin header (non-browser client)", "", true},
+		{"apex origin", "https://owt.craazzzyyfoxx.me", true},
+		{"tenant subdomain matches wildcard", "https://team-a.owt.craazzzyyfoxx.me", true},
+		{"another tenant subdomain", "https://another-team.owt.craazzzyyfoxx.me", true},
+		{"foreign origin rejected", "https://evil.example.com", false},
+		{"lookalike suffix rejected", "https://owt.craazzzyyfoxx.me.evil.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := dialWithOrigin(t, srv.URL, tt.origin)
+			allowed := err == nil
+			if allowed != tt.wantAllow {
+				t.Fatalf("origin %q: allowed=%v (err=%v), want allowed=%v", tt.origin, allowed, err, tt.wantAllow)
+			}
+		})
+	}
+}
+
+// TestWS_OriginAllowlist_EmptyFallsBackToInsecure documents the one path that
+// still reaches AcceptOptions.InsecureSkipVerify: an operator explicitly
+// clearing the allowlist. It must never be the default (see
+// TestWS_OriginAllowlist_ProductionDefault and
+// config.TestLoad_WSAllowedOriginsDefault).
+func TestWS_OriginAllowlist_EmptyFallsBackToInsecure(t *testing.T) {
+	h := NewHandler(NewHub(), auth.New(wsSecret), allowAuthorizer{allow: true}, fakeReplayer{},
+		30*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/ws", h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	if err := dialWithOrigin(t, srv.URL, "https://evil.example.com"); err != nil {
+		t.Fatalf("expected InsecureSkipVerify fallback to accept any origin, got: %v", err)
+	}
+}

--- a/gateway/internal/ws/origin_test.go
+++ b/gateway/internal/ws/origin_test.go
@@ -12,16 +12,14 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/CraazzzyyFoxx/anak-tournaments/gateway/internal/auth"
+	"github.com/CraazzzyyFoxx/anak-tournaments/gateway/internal/config"
 )
 
-// productionWSAllowedOrigins mirrors config.defaultWSAllowedOrigins (gateway/
-// internal/config/config.go). It is duplicated here, rather than imported,
-// to keep this package free of a config dependency; TestLoad_WSAllowedOriginsDefault
-// in internal/config guards the source of truth.
-var productionWSAllowedOrigins = []string{
-	"https://owt.craazzzyyfoxx.me",
-	"https://*.owt.craazzzyyfoxx.me",
-}
+// productionWSAllowedOrigins is config.DefaultWSAllowedOrigins, the exact
+// slice config.Load falls back to. Referencing the exported value (rather
+// than duplicating the literal) means this test and
+// config.TestLoad_WSAllowedOriginsDefault can't drift apart.
+var productionWSAllowedOrigins = config.DefaultWSAllowedOrigins
 
 // dialWithOrigin attempts the WS handshake against srvURL with the given
 // Origin header and reports whether the server accepted the connection.
@@ -78,12 +76,14 @@ func TestWS_OriginAllowlist_ProductionDefault(t *testing.T) {
 	}
 }
 
-// TestWS_OriginAllowlist_EmptyFallsBackToInsecure documents the one path that
-// still reaches AcceptOptions.InsecureSkipVerify: an operator explicitly
-// clearing the allowlist. It must never be the default (see
-// TestWS_OriginAllowlist_ProductionDefault and
-// config.TestLoad_WSAllowedOriginsDefault).
-func TestWS_OriginAllowlist_EmptyFallsBackToInsecure(t *testing.T) {
+// TestWS_OriginAllowlist_EmptyRejectsForeignOrigin proves the fail-closed
+// behaviour when an operator explicitly clears GATEWAY_WS_ALLOWED_ORIGINS:
+// NewHandler must never set AcceptOptions.InsecureSkipVerify. coder/websocket
+// always authorizes the request's own Host regardless of OriginPatterns (see
+// authenticateOrigin in its accept.go), so an empty allowlist degrades to
+// same-origin-only enforcement — a foreign cross-site handshake is rejected,
+// while a same-origin handshake (Origin host == request Host) still works.
+func TestWS_OriginAllowlist_EmptyRejectsForeignOrigin(t *testing.T) {
 	h := NewHandler(NewHub(), auth.New(wsSecret), allowAuthorizer{allow: true}, fakeReplayer{},
 		30*time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
 	mux := http.NewServeMux()
@@ -91,7 +91,16 @@ func TestWS_OriginAllowlist_EmptyFallsBackToInsecure(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	if err := dialWithOrigin(t, srv.URL, "https://evil.example.com"); err != nil {
-		t.Fatalf("expected InsecureSkipVerify fallback to accept any origin, got: %v", err)
+	if err := dialWithOrigin(t, srv.URL, "https://evil.example.com"); err == nil {
+		t.Fatal("expected empty allow-list to reject a foreign cross-origin handshake, but it was accepted")
+	}
+
+	// Same-origin (Origin host == request Host) must still work even with an
+	// empty allowlist: coder/websocket authorizes the request's own Host
+	// unconditionally. Only the host matters for that check, so reusing
+	// srv.URL (http scheme) as the Origin against the ws:// dial target is
+	// sufficient.
+	if err := dialWithOrigin(t, srv.URL, srv.URL); err != nil {
+		t.Fatalf("expected same-origin handshake to be accepted with empty allow-list, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds **per-workspace white-label branding** and **Phase 1 of multi-domain** (subdomains): each opted-in workspace is reachable at `{subdomain}.owt.craazzzyyfoxx.me` as a white-label site where the **host is the workspace** (host beats cookie). Includes a full OAuth rework so login round-trips through a single callback on any host, SSO across subdomains via domain-scoped cookies, per-workspace SEO, and hardened WebSocket origins.

Design + plan: `docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md`, `docs/superpowers/plans/2026-07-06-workspace-subdomains-phase1.md`.

## What's included

**Branding**
- Typed palette columns on `Workspace` + hex-validated schema + migration `wsbrand0001`; pure `deriveWorkspacePalette` util (dark-lightness clamp + WCAG contrast guards; role/chart tokens untouched); SSR seed + client `WorkspaceThemeSync`; admin editor.

**Multi-domain (Phase 1 — subdomains)**
- `subdomain` + `seo_title`/`seo_description` columns + migration `wsdomain0001`.
- `rpc.app.workspaces.by_host` resolver + Next.js `middleware.ts` (host→workspace, injects `x-owt-workspace-id`, fail-closed 503 on transient error, `/api` excluded from the matcher, bounded in-memory cache).
- **White-label lock:** SSR *and* the client store are scoped to the host workspace; switcher + "communities" hidden; the tenant header shows the workspace logo linking home.
- **OAuth:** single registered callback (`owt.craazzzyyfoxx.me/auth/callback`); origin/redirect/action carried in a signed HMAC state; **browser-binding CSRF** (`owt_oauth_csrf` cookie + `sha256` in state, backend fail-closed compare) closing login-CSRF and account-linking CSRF; `Domain=.owt.craazzzyyfoxx.me` session cookies (SSO across subdomains) with the `aqt_*`→`owt_*` rename (read-fallback, no forced logout; centralized `clearAuthCookies`/`getAccessToken` helpers).
- Per-host, per-workspace SEO (title / OG / favicon / canonical + host-scoped sitemap & robots; sitemap user fetch cached per workspace).
- WS origin allow `*.owt.craazzzyyfoxx.me`, failing closed to same-origin (no `InsecureSkipVerify`).
- Canonical env values + ops runbook (DNS / TLS / OAuth provider registration).

## Requires before enabling live (out of repo — see ops runbook)
- Wildcard DNS + TLS for `*.owt.craazzzyyfoxx.me` (Traefik DNS-01, apex in the cert SAN).
- Register `https://owt.craazzzyyfoxx.me/auth/callback` as the redirect URI in Discord / Twitch / Battle.net.
- `alembic upgrade head` (applies `wsbrand0001`, `wsdomain0001`).

## Test plan
- [x] Frontend `bun test` — 231 pass / 0 fail (38 files).
- [x] Gateway `go build` / `go vet` / `go test` green (incl. WS-origin + cookie table tests).
- [x] Backend schema + hostname unit tests green (`uv run pytest`).
- [x] `tsc --noEmit` + `eslint` clean.
- [ ] Manual E2E on a live subdomain: OAuth round-trips, session carries across subdomains, white-label lock (no switcher/communities), admin sets a subdomain, apex platform unaffected.

## Not included (follow-ups)
- **Phase 2 — custom domains** (`tourney.customer.com`): DNS verification + on-demand TLS + cross-domain SSO-ticket handoff (separate plan).
- Minor: explicit flag in `userService.getAll` instead of options-presence inference; extend the host-lock outside the `(site)` layout; dedupe the cookie-name constants (server vs client).
