### PR TITLE
Design-system unification (Editorial Tactical) + workspace branding/domain rework

### DIFF
--- a/backend/app-service/src/schemas/workspace.py
+++ b/backend/app-service/src/schemas/workspace.py
@@ -34,6 +34,12 @@ class WorkspaceRead(BaseRead):
     brand_secondary: str | None = None
     brand_background: str | None = None
     brand_surface: str | None = None
+    brand_accent: str | None = None
+    brand_foreground: str | None = None
+    brand_muted: str | None = None
+    brand_border: str | None = None
+    brand_ring: str | None = None
+    brand_destructive: str | None = None
     subdomain: str | None = None
     seo_title: str | None = None
     seo_description: str | None = None
@@ -65,6 +71,12 @@ class WorkspaceUpdate(BaseModel):
     brand_secondary: str | None = Field(default=None, pattern=_HEX_COLOR)
     brand_background: str | None = Field(default=None, pattern=_HEX_COLOR)
     brand_surface: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_accent: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_foreground: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_muted: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_border: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_ring: str | None = Field(default=None, pattern=_HEX_COLOR)
+    brand_destructive: str | None = Field(default=None, pattern=_HEX_COLOR)
     subdomain: str | None = None
     seo_title: str | None = None
     seo_description: str | None = None
@@ -75,6 +87,12 @@ class WorkspaceUpdate(BaseModel):
         "brand_secondary",
         "brand_background",
         "brand_surface",
+        "brand_accent",
+        "brand_foreground",
+        "brand_muted",
+        "brand_border",
+        "brand_ring",
+        "brand_destructive",
         mode="before",
     )
     @classmethod

--- a/backend/app-service/tests/test_workspace_branding_schema.py
+++ b/backend/app-service/tests/test_workspace_branding_schema.py
@@ -59,6 +59,47 @@ def test_update_strips_whitespace_around_hex():
     assert model.brand_primary == "#14b8a6"
 
 
+_CORE_PALETTE = (
+    "brand_accent",
+    "brand_foreground",
+    "brand_muted",
+    "brand_border",
+    "brand_ring",
+    "brand_destructive",
+)
+
+
+def test_update_accepts_core_palette_overrides():
+    model = schemas.WorkspaceUpdate(
+        brand_accent="#22d3ee",
+        brand_foreground="#f1f5f9",
+        brand_muted="#1e293b",
+        brand_border="#334155",
+        brand_ring="#22d3ee",
+        brand_destructive="#ef4444",
+    )
+    assert model.brand_accent == "#22d3ee"
+    assert model.brand_destructive == "#ef4444"
+
+
+@pytest.mark.parametrize("field", _CORE_PALETTE)
+def test_update_blank_core_palette_becomes_none(field):
+    model = schemas.WorkspaceUpdate(**{field: "   "})
+    assert getattr(model, field) is None
+
+
+@pytest.mark.parametrize("field", _CORE_PALETTE)
+def test_update_rejects_malformed_core_palette(field):
+    with pytest.raises(ValidationError):
+        schemas.WorkspaceUpdate(**{field: "not-a-hex"})
+
+
+def test_read_exposes_core_palette_fields():
+    fields = schemas.WorkspaceRead.model_fields
+    for name in _CORE_PALETTE:
+        assert name in fields
+
+
 def test_read_exposes_branding_fields():
     fields = schemas.WorkspaceRead.model_fields
     for name in (

--- a/backend/migrations/versions/wsbrand0002_add_workspace_core_palette.py
+++ b/backend/migrations/versions/wsbrand0002_add_workspace_core_palette.py
@@ -1,0 +1,43 @@
+"""add curated core-palette override columns to workspace branding
+
+Extends per-workspace branding from the four seed colours to a curated core
+palette: accent, foreground, muted, border, ring, destructive. All optional and
+nullable — when null the frontend derives them from the seeds; when set they
+override. Additive/nullable, so safe on a populated table.
+
+Revision ID: wsbrand0002
+Revises: wscustdom0001
+Create Date: 2026-07-07
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "wsbrand0002"
+down_revision: str | None = "wscustdom0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS = (
+    "brand_accent",
+    "brand_foreground",
+    "brand_muted",
+    "brand_border",
+    "brand_ring",
+    "brand_destructive",
+)
+
+
+def upgrade() -> None:
+    for name in _COLUMNS:
+        op.add_column("workspace", sa.Column(name, sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    for name in reversed(_COLUMNS):
+        op.drop_column("workspace", name)

--- a/backend/shared/models/tenancy/workspace.py
+++ b/backend/shared/models/tenancy/workspace.py
@@ -33,6 +33,15 @@ class Workspace(db.TimeStampIntegerMixin):
     brand_secondary: Mapped[str | None] = mapped_column(String(), nullable=True)
     brand_background: Mapped[str | None] = mapped_column(String(), nullable=True)
     brand_surface: Mapped[str | None] = mapped_column(String(), nullable=True)
+    # Curated core-palette overrides (optional). When null, the frontend derives
+    # these from the four seed colours above; when set, they win. Same typed hex
+    # (#RRGGBB) columns as the seeds — no JSON bag.
+    brand_accent: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_foreground: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_muted: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_border: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_ring: Mapped[str | None] = mapped_column(String(), nullable=True)
+    brand_destructive: Mapped[str | None] = mapped_column(String(), nullable=True)
     # White-label multi-domain (Phase 1: subdomains). See
     # docs/superpowers/specs/2026-07-06-workspace-multidomain-design.md.
     subdomain: Mapped[str | None] = mapped_column(String(63), unique=True, index=True, nullable=True)

--- a/frontend/src/app/admin/workspaces/[id]/page.tsx
+++ b/frontend/src/app/admin/workspaces/[id]/page.tsx
@@ -1,0 +1,597 @@
+"use client";
+
+import { use, useEffect, useState, type CSSProperties } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, CheckCircle, XCircle, Copy, Loader2 } from "lucide-react";
+
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { EditableAvatar } from "@/components/ui/editable-avatar";
+import { notify } from "@/lib/notify";
+import { usePermissions } from "@/hooks/usePermissions";
+import { deriveWorkspacePalette } from "@/lib/workspace-theme";
+import { PLATFORM_ZONE } from "@/lib/host";
+import workspaceService from "@/services/workspace.service";
+import { useWorkspaceStore } from "@/stores/workspace.store";
+import type { Workspace } from "@/types/workspace.types";
+
+const ACCEPTED_IMAGE_TYPES = "image/webp,image/png,image/jpeg,image/gif";
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+const VERIFY_POLL_MS = 15000;
+
+interface EditFormData {
+  name: string;
+  description: string;
+  branding_enabled: boolean;
+  brand_primary: string | null;
+  brand_secondary: string | null;
+  brand_background: string | null;
+  brand_surface: string | null;
+  brand_accent: string | null;
+  brand_foreground: string | null;
+  brand_muted: string | null;
+  brand_border: string | null;
+  brand_ring: string | null;
+  brand_destructive: string | null;
+  subdomain: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+}
+
+function formFromWorkspace(ws: Workspace): EditFormData {
+  return {
+    name: ws.name,
+    description: ws.description ?? "",
+    branding_enabled: ws.branding_enabled,
+    brand_primary: ws.brand_primary,
+    brand_secondary: ws.brand_secondary,
+    brand_background: ws.brand_background,
+    brand_surface: ws.brand_surface,
+    brand_accent: ws.brand_accent ?? null,
+    brand_foreground: ws.brand_foreground ?? null,
+    brand_muted: ws.brand_muted ?? null,
+    brand_border: ws.brand_border ?? null,
+    brand_ring: ws.brand_ring ?? null,
+    brand_destructive: ws.brand_destructive ?? null,
+    subdomain: ws.subdomain,
+    seo_title: ws.seo_title,
+    seo_description: ws.seo_description,
+  };
+}
+
+function BrandColorField({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string | null | undefined;
+  onChange: (value: string) => void;
+}) {
+  const hex = value ?? "";
+  const valid = /^#[0-9a-fA-F]{6}$/.test(hex);
+  return (
+    <div>
+      <Label htmlFor={id}>{label}</Label>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={`${label} color`}
+          value={valid ? hex : "#000000"}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-9 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
+        />
+        <Input
+          id={id}
+          value={hex}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="#000000"
+          className="font-mono"
+        />
+      </div>
+    </div>
+  );
+}
+
+const errorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error ? error.message : fallback;
+
+export default function WorkspaceEditPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = use(params);
+  const id = Number(idParam);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { isSuperuser, isWorkspaceAdmin, isLoaded } = usePermissions();
+  const fetchWorkspaces = useWorkspaceStore((s) => s.fetchWorkspaces);
+
+  const wsQuery = useQuery({
+    queryKey: ["admin-workspace", id],
+    queryFn: () => workspaceService.getById(id),
+    enabled: Number.isFinite(id),
+  });
+  const ws = wsQuery.data;
+
+  const [form, setForm] = useState<EditFormData | null>(null);
+  const [iconFile, setIconFile] = useState<File | null>(null);
+  const [iconPreview, setIconPreview] = useState<string | null>(null);
+  const [customDomainInput, setCustomDomainInput] = useState("");
+  const [domain, setDomain] = useState<{
+    domain: string | null;
+    verifiedAt: string | null;
+    token: string | null;
+  }>({ domain: null, verifiedAt: null, token: null });
+
+  // Seed local state once the workspace loads (guarded so a background refetch
+  // never clobbers in-progress edits).
+  const [seeded, setSeeded] = useState(false);
+  useEffect(() => {
+    if (!ws || seeded) return;
+    setForm(formFromWorkspace(ws));
+    setIconPreview(ws.icon_url ?? null);
+    setCustomDomainInput(ws.custom_domain ?? "");
+    setDomain({
+      domain: ws.custom_domain,
+      verifiedAt: ws.custom_domain_verified_at,
+      token: ws.custom_domain_verification_token,
+    });
+    setSeeded(true);
+  }, [ws, seeded]);
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["admin-workspaces"] });
+    queryClient.invalidateQueries({ queryKey: ["admin-workspace", id] });
+    fetchWorkspaces();
+  };
+
+  const applyDomainResult = (updated: Workspace) => {
+    setDomain({
+      domain: updated.custom_domain,
+      verifiedAt: updated.custom_domain_verified_at,
+      token: updated.custom_domain_verification_token,
+    });
+    setCustomDomainInput(updated.custom_domain ?? "");
+  };
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: Partial<EditFormData>) => {
+      await workspaceService.update(id, data);
+      if (iconFile) await workspaceService.uploadIcon(id, iconFile);
+    },
+    onSuccess: () => {
+      invalidate();
+      notify.success("Workspace updated");
+      router.push("/admin/workspaces");
+    },
+    onError: (error) => notify.error(errorMessage(error, "Failed to save workspace")),
+  });
+
+  const deleteIconMutation = useMutation({
+    mutationFn: () => workspaceService.deleteIcon(id),
+    onSuccess: () => {
+      invalidate();
+      setIconPreview(null);
+      notify.success("Icon removed");
+    },
+  });
+
+  const setDomainMutation = useMutation({
+    mutationFn: (value: string) => workspaceService.setCustomDomain(id, value),
+    onSuccess: (updated) => {
+      applyDomainResult(updated);
+      invalidate();
+      notify.success("Custom domain saved — add the DNS records below, then verify");
+    },
+    onError: (error) => notify.error(errorMessage(error, "Failed to save custom domain")),
+  });
+
+  const verifyMutation = useMutation({
+    mutationFn: () => workspaceService.verifyCustomDomain(id),
+    onSuccess: (updated) => {
+      applyDomainResult(updated);
+      invalidate();
+      notify.success("Custom domain verified");
+    },
+    onError: (error) =>
+      notify.error(
+        errorMessage(error, "Verification record not found yet — DNS changes can take time to propagate")
+      ),
+  });
+
+  const clearDomainMutation = useMutation({
+    mutationFn: () => workspaceService.clearCustomDomain(id),
+    onSuccess: (updated) => {
+      applyDomainResult(updated);
+      invalidate();
+      notify.success("Custom domain removed");
+    },
+    onError: (error) => notify.error(errorMessage(error, "Failed to remove custom domain")),
+  });
+
+  // Auto-poll verification while a domain is pending: the domain only goes live
+  // once verified, so we quietly re-check DNS on an interval (no toast spam) and
+  // stop as soon as it verifies. The manual "Verify" button stays for an
+  // immediate check.
+  const domainPending = !!domain.domain && !domain.verifiedAt;
+  const verifyPoll = useQuery({
+    queryKey: ["admin-workspace-domain-verify", id, domain.domain],
+    queryFn: () => workspaceService.verifyCustomDomain(id),
+    enabled: domainPending,
+    refetchInterval: domainPending ? VERIFY_POLL_MS : false,
+    refetchOnWindowFocus: false,
+    retry: false,
+    gcTime: 0,
+  });
+  useEffect(() => {
+    if (verifyPoll.data?.custom_domain_verified_at) {
+      applyDomainResult(verifyPoll.data);
+      invalidate();
+      notify.success("Custom domain verified");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [verifyPoll.data?.custom_domain_verified_at]);
+
+  const handleIconSelect = (file: File) => {
+    setIconFile(file);
+    setIconPreview(URL.createObjectURL(file));
+  };
+
+  const canManage = isLoaded && (isSuperuser || isWorkspaceAdmin(id));
+
+  const brandingPreview = form
+    ? deriveWorkspacePalette({ ...form, branding_enabled: true })
+    : null;
+
+  if (wsQuery.isLoading || !isLoaded) {
+    return (
+      <div className="flex items-center justify-center py-24 text-muted-foreground">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading workspace…
+      </div>
+    );
+  }
+
+  if (!ws || !form) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-24 text-center">
+        <p className="text-sm text-muted-foreground">Workspace not found.</p>
+        <Button asChild variant="outline">
+          <Link href="/admin/workspaces">Back to workspaces</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (!canManage) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-24 text-center">
+        <p className="text-sm text-muted-foreground">
+          You don&apos;t have permission to manage this workspace.
+        </p>
+        <Button asChild variant="outline">
+          <Link href="/admin/workspaces">Back to workspaces</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const handleCopy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      notify.success("Copied to clipboard");
+    } catch {
+      notify.error("Could not copy to clipboard");
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Blank colour → null (backend rejects "" via the #RRGGBB pattern; a missing
+    // token falls back to the derived default). Custom domain is its own flow.
+    const hexOrNull = (v: string | null) => v?.trim() || null;
+    updateMutation.mutate({
+      name: form.name,
+      description: form.description,
+      branding_enabled: form.branding_enabled,
+      brand_primary: hexOrNull(form.brand_primary),
+      brand_secondary: hexOrNull(form.brand_secondary),
+      brand_background: hexOrNull(form.brand_background),
+      brand_surface: hexOrNull(form.brand_surface),
+      brand_accent: hexOrNull(form.brand_accent),
+      brand_foreground: hexOrNull(form.brand_foreground),
+      brand_muted: hexOrNull(form.brand_muted),
+      brand_border: hexOrNull(form.brand_border),
+      brand_ring: hexOrNull(form.brand_ring),
+      brand_destructive: hexOrNull(form.brand_destructive),
+      subdomain: form.subdomain?.trim() || null,
+      seo_title: form.seo_title?.trim() || null,
+      seo_description: form.seo_description?.trim() || null,
+    });
+  };
+
+  const patch = (changes: Partial<EditFormData>) => setForm((f) => (f ? { ...f, ...changes } : f));
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-3xl flex-col gap-6 pb-16">
+      <AdminPageHeader
+        title={`Edit ${ws.name}`}
+        description={`Workspace “${ws.slug}” — branding, domains and metadata`}
+        actions={
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/admin/workspaces">
+              <ArrowLeft className="mr-2 h-4 w-4" /> Back
+            </Link>
+          </Button>
+        }
+      />
+
+      {/* Basics */}
+      <section className="space-y-4 rounded-lg border p-4">
+        <div>
+          <Label htmlFor="edit-name">Name</Label>
+          <Input id="edit-name" value={form.name} onChange={(e) => patch({ name: e.target.value })} />
+        </div>
+        <div>
+          <Label htmlFor="edit-description">Description</Label>
+          <Textarea
+            id="edit-description"
+            value={form.description}
+            onChange={(e) => patch({ description: e.target.value })}
+          />
+        </div>
+        <div>
+          <Label>Icon</Label>
+          <div className="mt-1.5">
+            <EditableAvatar
+              src={iconPreview}
+              name={form.name}
+              size={64}
+              shape="rounded"
+              busy={deleteIconMutation.isPending}
+              onSelectFile={handleIconSelect}
+              onDelete={
+                iconPreview
+                  ? () => {
+                      if (ws.icon_url && !iconFile) {
+                        deleteIconMutation.mutate();
+                      } else {
+                        setIconFile(null);
+                        setIconPreview(ws.icon_url || null);
+                      }
+                    }
+                  : undefined
+              }
+              accept={ACCEPTED_IMAGE_TYPES}
+              maxSizeBytes={MAX_FILE_SIZE}
+              onError={(message) => notify.error(message)}
+            />
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">PNG, JPEG, WebP or GIF, max 2 MB</p>
+        </div>
+      </section>
+
+      {/* Branding */}
+      <section className="space-y-3 rounded-lg border p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <Label htmlFor="branding-enabled">Site branding</Label>
+            <p className="text-xs text-muted-foreground">
+              Custom palette for this workspace on the main public site
+            </p>
+          </div>
+          <Switch
+            id="branding-enabled"
+            checked={form.branding_enabled}
+            onCheckedChange={(checked) => patch({ branding_enabled: checked })}
+          />
+        </div>
+
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Seed colours
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <BrandColorField id="brand-primary" label="Primary accent" value={form.brand_primary} onChange={(v) => patch({ brand_primary: v })} />
+          <BrandColorField id="brand-secondary" label="Secondary accent" value={form.brand_secondary} onChange={(v) => patch({ brand_secondary: v })} />
+          <BrandColorField id="brand-background" label="Background" value={form.brand_background} onChange={(v) => patch({ brand_background: v })} />
+          <BrandColorField id="brand-surface" label="Surface" value={form.brand_surface} onChange={(v) => patch({ brand_surface: v })} />
+        </div>
+
+        <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Core palette · optional overrides
+        </p>
+        <p className="-mt-2 text-[11px] text-muted-foreground">
+          Leave blank to derive from the seed colours above.
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <BrandColorField id="brand-accent" label="Accent" value={form.brand_accent} onChange={(v) => patch({ brand_accent: v })} />
+          <BrandColorField id="brand-foreground" label="Foreground (text)" value={form.brand_foreground} onChange={(v) => patch({ brand_foreground: v })} />
+          <BrandColorField id="brand-muted" label="Muted surface" value={form.brand_muted} onChange={(v) => patch({ brand_muted: v })} />
+          <BrandColorField id="brand-border" label="Border" value={form.brand_border} onChange={(v) => patch({ brand_border: v })} />
+          <BrandColorField id="brand-ring" label="Focus ring" value={form.brand_ring} onChange={(v) => patch({ brand_ring: v })} />
+          <BrandColorField id="brand-destructive" label="Destructive" value={form.brand_destructive} onChange={(v) => patch({ brand_destructive: v })} />
+        </div>
+
+        {brandingPreview ? (
+          <div
+            className="rounded-md border p-3"
+            style={{ ...brandingPreview, background: "var(--aqt-bg)" } as CSSProperties}
+          >
+            <div className="text-xs font-medium" style={{ color: "var(--aqt-fg)" }}>
+              Preview
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <span className="rounded px-2 py-1 text-xs font-medium" style={{ background: "var(--aqt-teal)", color: "hsl(var(--primary-foreground))" }}>
+                Primary
+              </span>
+              <span className="rounded px-2 py-1 text-xs font-medium" style={{ background: "var(--aqt-violet)", color: "hsl(var(--secondary-foreground))" }}>
+                Secondary
+              </span>
+              <span className="rounded px-2 py-1 text-xs" style={{ background: "var(--aqt-card)", color: "var(--aqt-fg-muted)", border: "1px solid var(--aqt-border)" }}>
+                Surface
+              </span>
+              <span className="rounded px-2 py-1 text-xs font-medium" style={{ background: "hsl(var(--destructive))", color: "hsl(var(--destructive-foreground))" }}>
+                Destructive
+              </span>
+            </div>
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Set at least a primary accent and a background to preview. Backgrounds are clamped to a
+            dark shade to keep text readable.
+          </p>
+        )}
+      </section>
+
+      {/* Domains & SEO */}
+      <section className="space-y-4 rounded-lg border p-4">
+        <div>
+          <Label htmlFor="edit-subdomain">Subdomain</Label>
+          <Input
+            id="edit-subdomain"
+            value={form.subdomain ?? ""}
+            onChange={(e) => patch({ subdomain: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "") })}
+            placeholder="my-team"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {form.subdomain ? `${form.subdomain}.${PLATFORM_ZONE}` : "Leave blank to use the platform URL only"}
+          </p>
+        </div>
+
+        <div className="space-y-2 border-t pt-4">
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="edit-custom-domain">Custom domain</Label>
+            {domain.verifiedAt ? (
+              <Badge variant="secondary" className="gap-1">
+                <CheckCircle className="h-3 w-3 text-emerald-500" /> Verified · live
+              </Badge>
+            ) : domain.domain ? (
+              <Badge variant="outline" className="gap-1">
+                <Loader2 className="h-3 w-3 animate-spin text-amber-500" /> Pending — checking DNS…
+              </Badge>
+            ) : null}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              id="edit-custom-domain"
+              value={customDomainInput}
+              onChange={(e) => setCustomDomainInput(e.target.value.toLowerCase().trim())}
+              placeholder="tourney.example.com"
+              disabled={!!domain.verifiedAt}
+            />
+            {domain.verifiedAt ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="text-destructive"
+                disabled={clearDomainMutation.isPending}
+                onClick={() => clearDomainMutation.mutate()}
+              >
+                Remove
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!customDomainInput || setDomainMutation.isPending}
+                onClick={() => setDomainMutation.mutate(customDomainInput)}
+              >
+                {setDomainMutation.isPending ? "Saving…" : "Save domain"}
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Your workspace goes live on this domain <strong>only after verification</strong>. Leave
+            blank to use the platform URL / subdomain only.
+          </p>
+
+          {domain.domain && !domain.verifiedAt ? (
+            <div className="space-y-3 rounded-md border bg-muted/30 p-3">
+              <div>
+                <p className="text-xs font-semibold">How to connect your domain</p>
+                <ol className="mt-1 list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
+                  <li>Open your DNS provider (Cloudflare, Namecheap, GoDaddy…).</li>
+                  <li>Add the two records below exactly as shown.</li>
+                  <li>
+                    DNS can take a few minutes to propagate — we re-check automatically every 15s,
+                    or press <strong>Verify now</strong>.
+                  </li>
+                </ol>
+              </div>
+              <div className="space-y-1.5 text-xs">
+                <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 font-mono">
+                  <span className="text-muted-foreground">TXT</span>
+                  <span className="break-all">{`_owt-verify.${domain.domain}`}</span>
+                  <span className="break-all text-muted-foreground">(ownership)</span>
+                  <span className="text-muted-foreground">↳ value</span>
+                  <span className="break-all">{domain.token}</span>
+                  {domain.token ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5"
+                      aria-label="Copy TXT value"
+                      onClick={() => domain.token && handleCopy(domain.token)}
+                    >
+                      <Copy className="h-3 w-3" />
+                    </Button>
+                  ) : (
+                    <span />
+                  )}
+                </div>
+                <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 font-mono">
+                  <span className="text-muted-foreground">CNAME</span>
+                  <span className="break-all">{domain.domain}</span>
+                  <span className="break-all text-muted-foreground">→ {PLATFORM_ZONE}</span>
+                </div>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                disabled={verifyMutation.isPending}
+                onClick={() => verifyMutation.mutate()}
+              >
+                {verifyMutation.isPending ? "Checking…" : "Verify now"}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        <div>
+          <Label htmlFor="edit-seo-title">SEO title</Label>
+          <Input
+            id="edit-seo-title"
+            value={form.seo_title ?? ""}
+            onChange={(e) => patch({ seo_title: e.target.value })}
+            placeholder="Displayed in browser tabs and search results"
+          />
+        </div>
+        <div>
+          <Label htmlFor="edit-seo-description">SEO description</Label>
+          <Textarea
+            id="edit-seo-description"
+            value={form.seo_description ?? ""}
+            onChange={(e) => patch({ seo_description: e.target.value })}
+            placeholder="Optional meta description shown in search results"
+          />
+        </div>
+      </section>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button asChild variant="ghost">
+          <Link href="/admin/workspaces">Cancel</Link>
+        </Button>
+        <Button type="submit" disabled={updateMutation.isPending}>
+          {updateMutation.isPending ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/app/admin/workspaces/page.tsx
+++ b/frontend/src/app/admin/workspaces/page.tsx
@@ -40,6 +40,12 @@ interface WorkspaceUpdateFormData {
   brand_secondary?: string | null;
   brand_background?: string | null;
   brand_surface?: string | null;
+  brand_accent?: string | null;
+  brand_foreground?: string | null;
+  brand_muted?: string | null;
+  brand_border?: string | null;
+  brand_ring?: string | null;
+  brand_destructive?: string | null;
   subdomain?: string | null;
   seo_title?: string | null;
   seo_description?: string | null;
@@ -256,6 +262,12 @@ export default function WorkspacesPage() {
       brand_secondary: ws.brand_secondary,
       brand_background: ws.brand_background,
       brand_surface: ws.brand_surface,
+      brand_accent: ws.brand_accent,
+      brand_foreground: ws.brand_foreground,
+      brand_muted: ws.brand_muted,
+      brand_border: ws.brand_border,
+      brand_ring: ws.brand_ring,
+      brand_destructive: ws.brand_destructive,
       subdomain: ws.subdomain,
       seo_title: ws.seo_title,
       seo_description: ws.seo_description,
@@ -359,6 +371,12 @@ export default function WorkspacesPage() {
     brand_secondary: editForm.brand_secondary ?? null,
     brand_background: editForm.brand_background ?? null,
     brand_surface: editForm.brand_surface ?? null,
+    brand_accent: editForm.brand_accent ?? null,
+    brand_foreground: editForm.brand_foreground ?? null,
+    brand_muted: editForm.brand_muted ?? null,
+    brand_border: editForm.brand_border ?? null,
+    brand_ring: editForm.brand_ring ?? null,
+    brand_destructive: editForm.brand_destructive ?? null,
   });
 
   return (
@@ -504,6 +522,12 @@ export default function WorkspacesPage() {
               brand_secondary: hexOrNull(form.brand_secondary),
               brand_background: hexOrNull(form.brand_background),
               brand_surface: hexOrNull(form.brand_surface),
+              brand_accent: hexOrNull(form.brand_accent),
+              brand_foreground: hexOrNull(form.brand_foreground),
+              brand_muted: hexOrNull(form.brand_muted),
+              brand_border: hexOrNull(form.brand_border),
+              brand_ring: hexOrNull(form.brand_ring),
+              brand_destructive: hexOrNull(form.brand_destructive),
             },
           });
         }}
@@ -600,6 +624,51 @@ export default function WorkspacesPage() {
                 label="Surface"
                 value={editForm.brand_surface}
                 onChange={(v) => setFormData({ ...formData, brand_surface: v })}
+              />
+            </div>
+
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Core palette · optional overrides
+            </p>
+            <p className="-mt-2 text-[11px] text-muted-foreground">
+              Leave blank to derive from the seed colours above.
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              <BrandColorField
+                id="brand-accent"
+                label="Accent"
+                value={editForm.brand_accent}
+                onChange={(v) => setFormData({ ...formData, brand_accent: v })}
+              />
+              <BrandColorField
+                id="brand-foreground"
+                label="Foreground (text)"
+                value={editForm.brand_foreground}
+                onChange={(v) => setFormData({ ...formData, brand_foreground: v })}
+              />
+              <BrandColorField
+                id="brand-muted"
+                label="Muted surface"
+                value={editForm.brand_muted}
+                onChange={(v) => setFormData({ ...formData, brand_muted: v })}
+              />
+              <BrandColorField
+                id="brand-border"
+                label="Border"
+                value={editForm.brand_border}
+                onChange={(v) => setFormData({ ...formData, brand_border: v })}
+              />
+              <BrandColorField
+                id="brand-ring"
+                label="Focus ring"
+                value={editForm.brand_ring}
+                onChange={(v) => setFormData({ ...formData, brand_ring: v })}
+              />
+              <BrandColorField
+                id="brand-destructive"
+                label="Destructive"
+                value={editForm.brand_destructive}
+                onChange={(v) => setFormData({ ...formData, brand_destructive: v })}
               />
             </div>
 

--- a/frontend/src/app/admin/workspaces/page.tsx
+++ b/frontend/src/app/admin/workspaces/page.tsx
@@ -1,26 +1,23 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ColumnDef } from "@tanstack/react-table";
-import { Plus, Pencil, Trash2, CheckCircle, XCircle, Copy } from "lucide-react";
+import { Plus, Pencil, Trash2, CheckCircle, XCircle } from "lucide-react";
 import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { AdminDataTable } from "@/components/admin/AdminDataTable";
 import { StatusIcon } from "@/components/admin/StatusIcon";
 import { EntityFormDialog } from "@/components/admin/EntityFormDialog";
 import { DeleteConfirmDialog } from "@/components/admin/DeleteConfirmDialog";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { EditableAvatar } from "@/components/ui/editable-avatar";
 import { notify } from "@/lib/notify";
 import { usePermissions } from "@/hooks/usePermissions";
 import { hasUnsavedChanges } from "@/lib/form-change";
-import { deriveWorkspacePalette } from "@/lib/workspace-theme";
-import { PLATFORM_ZONE } from "@/lib/host";
 import workspaceService from "@/services/workspace.service";
 import { Workspace } from "@/types/workspace.types";
 import { useWorkspaceStore } from "@/stores/workspace.store";
@@ -29,62 +26,6 @@ interface WorkspaceFormData {
   slug: string;
   name: string;
   description: string;
-}
-
-interface WorkspaceUpdateFormData {
-  name?: string;
-  description?: string;
-  is_active?: boolean;
-  branding_enabled?: boolean;
-  brand_primary?: string | null;
-  brand_secondary?: string | null;
-  brand_background?: string | null;
-  brand_surface?: string | null;
-  brand_accent?: string | null;
-  brand_foreground?: string | null;
-  brand_muted?: string | null;
-  brand_border?: string | null;
-  brand_ring?: string | null;
-  brand_destructive?: string | null;
-  subdomain?: string | null;
-  seo_title?: string | null;
-  seo_description?: string | null;
-}
-
-function BrandColorField({
-  id,
-  label,
-  value,
-  onChange,
-}: {
-  id: string;
-  label: string;
-  value: string | null | undefined;
-  onChange: (value: string) => void;
-}) {
-  const hex = value ?? "";
-  const valid = /^#[0-9a-fA-F]{6}$/.test(hex);
-  return (
-    <div>
-      <Label htmlFor={id}>{label}</Label>
-      <div className="mt-1 flex items-center gap-2">
-        <input
-          type="color"
-          aria-label={`${label} color`}
-          value={valid ? hex : "#000000"}
-          onChange={(e) => onChange(e.target.value)}
-          className="h-9 w-10 shrink-0 cursor-pointer rounded border border-input bg-transparent p-0.5"
-        />
-        <Input
-          id={id}
-          value={hex}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder="#000000"
-          className="font-mono"
-        />
-      </div>
-    </div>
-  );
 }
 
 const emptyForm: WorkspaceFormData = {
@@ -98,28 +39,16 @@ const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 export default function WorkspacesPage() {
   const { isSuperuser, isWorkspaceAdmin } = usePermissions();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const fetchWorkspaces = useWorkspaceStore((s) => s.fetchWorkspaces);
 
   const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [selected, setSelected] = useState<Workspace | null>(null);
-  const [formData, setFormData] = useState<WorkspaceFormData | WorkspaceUpdateFormData>({
-    ...emptyForm
-  });
+  const [formData, setFormData] = useState<WorkspaceFormData>({ ...emptyForm });
   const [iconFile, setIconFile] = useState<File | null>(null);
   const [iconPreview, setIconPreview] = useState<string | null>(null);
-
-  // Custom domain (white-label Phase 2) is its own set/verify/clear RPC flow,
-  // not part of the main WorkspaceUpdate PATCH — tracked separately from
-  // `formData` so its buttons act immediately instead of waiting for Save.
-  const [customDomainInput, setCustomDomainInput] = useState("");
-  const [customDomain, setCustomDomain] = useState<{
-    domain: string | null;
-    verifiedAt: string | null;
-    token: string | null;
-  }>({ domain: null, verifiedAt: null, token: null });
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["admin-workspaces"] });
@@ -148,22 +77,6 @@ export default function WorkspacesPage() {
     }
   });
 
-  const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: number; data: WorkspaceUpdateFormData }) => {
-      await workspaceService.update(id, data);
-      if (iconFile) {
-        await workspaceService.uploadIcon(id, iconFile);
-      }
-    },
-    onSuccess: () => {
-      invalidate();
-      setEditOpen(false);
-      setIconFile(null);
-      setIconPreview(null);
-      notify.success("Workspace updated");
-    }
-  });
-
   const deleteMutation = useMutation({
     mutationFn: (id: number) =>
       fetch(`/api/v1/workspaces/${id}`, { method: "DELETE" }).then((r) => {
@@ -176,111 +89,11 @@ export default function WorkspacesPage() {
     }
   });
 
-  const uploadIconMutation = useMutation({
-    mutationFn: ({ id, file }: { id: number; file: File }) => workspaceService.uploadIcon(id, file),
-    onSuccess: () => {
-      invalidate();
-      notify.success("Icon uploaded");
-    }
-  });
-
-  const deleteIconMutation = useMutation({
-    mutationFn: (id: number) => workspaceService.deleteIcon(id),
-    onSuccess: () => {
-      invalidate();
-      setIconPreview(null);
-      notify.success("Icon removed");
-    }
-  });
-
-  const applyCustomDomainResult = (ws: Workspace) => {
-    setCustomDomain({
-      domain: ws.custom_domain,
-      verifiedAt: ws.custom_domain_verified_at,
-      token: ws.custom_domain_verification_token
-    });
-    setCustomDomainInput(ws.custom_domain ?? "");
-  };
-
-  const errorMessage = (error: unknown, fallback: string): string =>
-    error instanceof Error ? error.message : fallback;
-
-  const setCustomDomainMutation = useMutation({
-    mutationFn: ({ id, domain }: { id: number; domain: string }) => workspaceService.setCustomDomain(id, domain),
-    onSuccess: (ws) => {
-      applyCustomDomainResult(ws);
-      invalidate();
-      notify.success("Custom domain saved — add the DNS records below, then verify");
-    },
-    onError: (error) => notify.error(errorMessage(error, "Failed to save custom domain"))
-  });
-
-  const verifyCustomDomainMutation = useMutation({
-    mutationFn: (id: number) => workspaceService.verifyCustomDomain(id),
-    onSuccess: (ws) => {
-      applyCustomDomainResult(ws);
-      invalidate();
-      notify.success("Custom domain verified");
-    },
-    onError: (error) =>
-      notify.error(errorMessage(error, "Verification record not found yet — DNS changes can take time to propagate"))
-  });
-
-  const clearCustomDomainMutation = useMutation({
-    mutationFn: (id: number) => workspaceService.clearCustomDomain(id),
-    onSuccess: (ws) => {
-      applyCustomDomainResult(ws);
-      invalidate();
-      notify.success("Custom domain removed");
-    },
-    onError: (error) => notify.error(errorMessage(error, "Failed to remove custom domain"))
-  });
-
-  const handleCopy = async (value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      notify.success("Copied to clipboard");
-    } catch {
-      notify.error("Could not copy to clipboard");
-    }
-  };
-
   const handleCreate = () => {
     setFormData({ ...emptyForm });
     setIconFile(null);
     setIconPreview(null);
     setCreateOpen(true);
-  };
-
-  const handleEdit = (ws: Workspace) => {
-    setSelected(ws);
-    setFormData({
-      name: ws.name,
-      description: ws.description || "",
-      branding_enabled: ws.branding_enabled,
-      brand_primary: ws.brand_primary,
-      brand_secondary: ws.brand_secondary,
-      brand_background: ws.brand_background,
-      brand_surface: ws.brand_surface,
-      brand_accent: ws.brand_accent,
-      brand_foreground: ws.brand_foreground,
-      brand_muted: ws.brand_muted,
-      brand_border: ws.brand_border,
-      brand_ring: ws.brand_ring,
-      brand_destructive: ws.brand_destructive,
-      subdomain: ws.subdomain,
-      seo_title: ws.seo_title,
-      seo_description: ws.seo_description,
-    });
-    setIconFile(null);
-    setIconPreview(ws.icon_url || null);
-    setCustomDomainInput(ws.custom_domain ?? "");
-    setCustomDomain({
-      domain: ws.custom_domain,
-      verifiedAt: ws.custom_domain_verified_at,
-      token: ws.custom_domain_verification_token
-    });
-    setEditOpen(true);
   };
 
   const handleIconSelect = (file: File) => {
@@ -344,7 +157,12 @@ export default function WorkspacesPage() {
 
         return (
           <div className="flex items-center gap-1">
-            <Button variant="ghost" size="icon" onClick={() => handleEdit(ws)} aria-label="Edit">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => router.push(`/admin/workspaces/${ws.id}`)}
+              aria-label="Edit"
+            >
               <Pencil className="h-4 w-4" />
             </Button>
             {isSuperuser ? (
@@ -363,21 +181,6 @@ export default function WorkspacesPage() {
       }
     }
   ];
-
-  const editForm = formData as WorkspaceUpdateFormData;
-  const brandingPreview = deriveWorkspacePalette({
-    branding_enabled: true,
-    brand_primary: editForm.brand_primary ?? null,
-    brand_secondary: editForm.brand_secondary ?? null,
-    brand_background: editForm.brand_background ?? null,
-    brand_surface: editForm.brand_surface ?? null,
-    brand_accent: editForm.brand_accent ?? null,
-    brand_foreground: editForm.brand_foreground ?? null,
-    brand_muted: editForm.brand_muted ?? null,
-    brand_border: editForm.brand_border ?? null,
-    brand_ring: editForm.brand_ring ?? null,
-    brand_destructive: editForm.brand_destructive ?? null,
-  });
 
   return (
     <div className="flex flex-col gap-6">
@@ -428,7 +231,7 @@ export default function WorkspacesPage() {
         description="Create a new isolated workspace for tournaments"
         onSubmit={(e) => {
           e.preventDefault();
-          createMutation.mutate(formData as WorkspaceFormData);
+          createMutation.mutate(formData);
         }}
         isSubmitting={createMutation.isPending}
         submittingLabel="Creating..."
@@ -440,7 +243,7 @@ export default function WorkspacesPage() {
             <Label htmlFor="slug">Slug *</Label>
             <Input
               id="slug"
-              value={(formData as WorkspaceFormData).slug ?? ""}
+              value={formData.slug}
               onChange={(e) =>
                 setFormData({
                   ...formData,
@@ -458,7 +261,7 @@ export default function WorkspacesPage() {
             <Label htmlFor="name">Name *</Label>
             <Input
               id="name"
-              value={formData.name ?? ""}
+              value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               placeholder="My Workspace"
               required
@@ -468,7 +271,7 @@ export default function WorkspacesPage() {
             <Label htmlFor="description">Description</Label>
             <Textarea
               id="description"
-              value={formData.description ?? ""}
+              value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               placeholder="Optional description"
             />
@@ -496,360 +299,6 @@ export default function WorkspacesPage() {
               />
             </div>
             <p className="text-xs text-muted-foreground mt-1">PNG, JPEG, WebP or GIF, max 2 MB</p>
-          </div>
-        </div>
-      </EntityFormDialog>
-
-      {/* Edit Dialog */}
-      <EntityFormDialog
-        open={editOpen}
-        onOpenChange={setEditOpen}
-        title="Edit Workspace"
-        description={`Editing "${selected?.name}"`}
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!selected) return;
-          const form = formData as WorkspaceUpdateFormData;
-          // A blank colour field means "keep the default" → send null (the
-          // backend rejects "" via the #RRGGBB pattern, and the derive util
-          // treats a missing token as the default palette value).
-          const hexOrNull = (v: string | null | undefined) => v?.trim() || null;
-          updateMutation.mutate({
-            id: selected.id,
-            data: {
-              ...form,
-              brand_primary: hexOrNull(form.brand_primary),
-              brand_secondary: hexOrNull(form.brand_secondary),
-              brand_background: hexOrNull(form.brand_background),
-              brand_surface: hexOrNull(form.brand_surface),
-              brand_accent: hexOrNull(form.brand_accent),
-              brand_foreground: hexOrNull(form.brand_foreground),
-              brand_muted: hexOrNull(form.brand_muted),
-              brand_border: hexOrNull(form.brand_border),
-              brand_ring: hexOrNull(form.brand_ring),
-              brand_destructive: hexOrNull(form.brand_destructive),
-            },
-          });
-        }}
-        isSubmitting={updateMutation.isPending}
-        submittingLabel="Saving..."
-        errorMessage={updateMutation.isError ? updateMutation.error.message : undefined}
-      >
-        <div className="space-y-4">
-          <div>
-            <Label htmlFor="edit-name">Name</Label>
-            <Input
-              id="edit-name"
-              value={formData.name ?? ""}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            />
-          </div>
-          <div>
-            <Label htmlFor="edit-description">Description</Label>
-            <Textarea
-              id="edit-description"
-              value={formData.description ?? ""}
-              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-            />
-          </div>
-          <div>
-            <Label>Icon</Label>
-            <div className="mt-1.5">
-              <EditableAvatar
-                src={iconPreview}
-                name={formData.name}
-                size={64}
-                shape="rounded"
-                busy={deleteIconMutation.isPending}
-                onSelectFile={handleIconSelect}
-                onDelete={
-                  iconPreview
-                    ? () => {
-                        if (selected?.icon_url && !iconFile) {
-                          deleteIconMutation.mutate(selected.id);
-                        } else {
-                          setIconFile(null);
-                          setIconPreview(selected?.icon_url || null);
-                        }
-                      }
-                    : undefined
-                }
-                accept={ACCEPTED_IMAGE_TYPES}
-                maxSizeBytes={MAX_FILE_SIZE}
-                onError={(message) => notify.error(message)}
-              />
-            </div>
-            <p className="text-xs text-muted-foreground mt-1">PNG, JPEG, WebP or GIF, max 2 MB</p>
-          </div>
-
-          {/* Branding — applies to the main public site only */}
-          <div className="space-y-3 rounded-md border p-3">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <Label htmlFor="branding-enabled">Site branding</Label>
-                <p className="text-xs text-muted-foreground">
-                  Custom palette for this workspace on the main site
-                </p>
-              </div>
-              <Switch
-                id="branding-enabled"
-                checked={editForm.branding_enabled ?? false}
-                onCheckedChange={(checked) =>
-                  setFormData({ ...formData, branding_enabled: checked })
-                }
-              />
-            </div>
-
-            <div className="grid grid-cols-2 gap-3">
-              <BrandColorField
-                id="brand-primary"
-                label="Primary accent"
-                value={editForm.brand_primary}
-                onChange={(v) => setFormData({ ...formData, brand_primary: v })}
-              />
-              <BrandColorField
-                id="brand-secondary"
-                label="Secondary accent"
-                value={editForm.brand_secondary}
-                onChange={(v) => setFormData({ ...formData, brand_secondary: v })}
-              />
-              <BrandColorField
-                id="brand-background"
-                label="Background"
-                value={editForm.brand_background}
-                onChange={(v) => setFormData({ ...formData, brand_background: v })}
-              />
-              <BrandColorField
-                id="brand-surface"
-                label="Surface"
-                value={editForm.brand_surface}
-                onChange={(v) => setFormData({ ...formData, brand_surface: v })}
-              />
-            </div>
-
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Core palette · optional overrides
-            </p>
-            <p className="-mt-2 text-[11px] text-muted-foreground">
-              Leave blank to derive from the seed colours above.
-            </p>
-            <div className="grid grid-cols-2 gap-3">
-              <BrandColorField
-                id="brand-accent"
-                label="Accent"
-                value={editForm.brand_accent}
-                onChange={(v) => setFormData({ ...formData, brand_accent: v })}
-              />
-              <BrandColorField
-                id="brand-foreground"
-                label="Foreground (text)"
-                value={editForm.brand_foreground}
-                onChange={(v) => setFormData({ ...formData, brand_foreground: v })}
-              />
-              <BrandColorField
-                id="brand-muted"
-                label="Muted surface"
-                value={editForm.brand_muted}
-                onChange={(v) => setFormData({ ...formData, brand_muted: v })}
-              />
-              <BrandColorField
-                id="brand-border"
-                label="Border"
-                value={editForm.brand_border}
-                onChange={(v) => setFormData({ ...formData, brand_border: v })}
-              />
-              <BrandColorField
-                id="brand-ring"
-                label="Focus ring"
-                value={editForm.brand_ring}
-                onChange={(v) => setFormData({ ...formData, brand_ring: v })}
-              />
-              <BrandColorField
-                id="brand-destructive"
-                label="Destructive"
-                value={editForm.brand_destructive}
-                onChange={(v) => setFormData({ ...formData, brand_destructive: v })}
-              />
-            </div>
-
-            {brandingPreview ? (
-              <div
-                className="rounded-md border p-3"
-                style={{ ...brandingPreview, background: "var(--aqt-bg)" } as CSSProperties}
-              >
-                <div className="text-xs font-medium" style={{ color: "var(--aqt-fg)" }}>
-                  Preview
-                </div>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  <span
-                    className="rounded px-2 py-1 text-xs font-medium"
-                    style={{
-                      background: "var(--aqt-teal)",
-                      color: "hsl(var(--primary-foreground))",
-                    }}
-                  >
-                    Primary
-                  </span>
-                  <span
-                    className="rounded px-2 py-1 text-xs font-medium"
-                    style={{
-                      background: "var(--aqt-violet)",
-                      color: "hsl(var(--secondary-foreground))",
-                    }}
-                  >
-                    Secondary
-                  </span>
-                  <span
-                    className="rounded px-2 py-1 text-xs"
-                    style={{
-                      background: "var(--aqt-card)",
-                      color: "var(--aqt-fg-muted)",
-                      border: "1px solid var(--aqt-border)",
-                    }}
-                  >
-                    Surface
-                  </span>
-                </div>
-              </div>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                Set at least a primary accent and a background to preview. Backgrounds are
-                clamped to a dark shade to keep text readable.
-              </p>
-            )}
-          </div>
-
-          {/* Domain & SEO — subdomain routing + public metadata */}
-          <div className="space-y-3 rounded-md border p-3">
-            <div>
-              <Label htmlFor="edit-subdomain">Subdomain</Label>
-              <Input
-                id="edit-subdomain"
-                value={editForm.subdomain ?? ""}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    subdomain: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "")
-                  })
-                }
-                placeholder="my-team"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                {editForm.subdomain
-                  ? `${editForm.subdomain}.${PLATFORM_ZONE}`
-                  : "Leave blank to use the platform URL only"}
-              </p>
-            </div>
-
-            <div className="space-y-2 border-t pt-3">
-              <div className="flex items-center justify-between gap-2">
-                <Label htmlFor="edit-custom-domain">Custom domain</Label>
-                {customDomain.verifiedAt ? (
-                  <Badge variant="secondary" className="gap-1">
-                    <CheckCircle className="h-3 w-3 text-emerald-500" />
-                    Verified
-                  </Badge>
-                ) : customDomain.domain ? (
-                  <Badge variant="outline" className="gap-1">
-                    <XCircle className="h-3 w-3 text-amber-500" />
-                    Pending verification
-                  </Badge>
-                ) : null}
-              </div>
-              <div className="flex gap-2">
-                <Input
-                  id="edit-custom-domain"
-                  value={customDomainInput}
-                  onChange={(e) => setCustomDomainInput(e.target.value.toLowerCase().trim())}
-                  placeholder="tourney.example.com"
-                  disabled={!!customDomain.verifiedAt}
-                />
-                {customDomain.verifiedAt ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="text-destructive"
-                    disabled={!selected || clearCustomDomainMutation.isPending}
-                    onClick={() => selected && clearCustomDomainMutation.mutate(selected.id)}
-                  >
-                    Remove
-                  </Button>
-                ) : (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={!selected || !customDomainInput || setCustomDomainMutation.isPending}
-                    onClick={() =>
-                      selected &&
-                      setCustomDomainMutation.mutate({ id: selected.id, domain: customDomainInput })
-                    }
-                  >
-                    {setCustomDomainMutation.isPending ? "Saving..." : "Save"}
-                  </Button>
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Serves this workspace on your own domain once verified. Leave blank to use the
-                platform URL / subdomain only.
-              </p>
-
-              {customDomain.domain && !customDomain.verifiedAt ? (
-                <div className="space-y-2 rounded-md border bg-muted/30 p-3">
-                  <p className="text-xs font-medium">Add these DNS records, then verify:</p>
-                  <div className="space-y-1.5 text-xs">
-                    <div className="flex flex-wrap items-center gap-2 font-mono">
-                      <span className="shrink-0 text-muted-foreground">TXT</span>
-                      <span className="break-all">{`_owt-verify.${customDomain.domain}`}</span>
-                      <span className="break-all">{customDomain.token}</span>
-                      {customDomain.token ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="h-5 w-5"
-                          aria-label="Copy TXT value"
-                          onClick={() => customDomain.token && handleCopy(customDomain.token)}
-                        >
-                          <Copy className="h-3 w-3" />
-                        </Button>
-                      ) : null}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 font-mono">
-                      <span className="shrink-0 text-muted-foreground">CNAME</span>
-                      <span className="break-all">{customDomain.domain}</span>
-                      <span className="break-all">{PLATFORM_ZONE}</span>
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={!selected || verifyCustomDomainMutation.isPending}
-                    onClick={() => selected && verifyCustomDomainMutation.mutate(selected.id)}
-                  >
-                    {verifyCustomDomainMutation.isPending ? "Checking..." : "Verify"}
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-
-            <div>
-              <Label htmlFor="edit-seo-title">SEO title</Label>
-              <Input
-                id="edit-seo-title"
-                value={editForm.seo_title ?? ""}
-                onChange={(e) => setFormData({ ...formData, seo_title: e.target.value })}
-                placeholder="Displayed in browser tabs and search results"
-              />
-            </div>
-            <div>
-              <Label htmlFor="edit-seo-description">SEO description</Label>
-              <Textarea
-                id="edit-seo-description"
-                value={editForm.seo_description ?? ""}
-                onChange={(e) => setFormData({ ...formData, seo_description: e.target.value })}
-                placeholder="Optional meta description shown in search results"
-              />
-            </div>
           </div>
         </div>
       </EntityFormDialog>

--- a/frontend/src/lib/workspace-theme.test.ts
+++ b/frontend/src/lib/workspace-theme.test.ts
@@ -86,11 +86,36 @@ describe("deriveWorkspacePalette", () => {
       "--aqt-gold",
       "--aqt-rose",
       "--aqt-blue",
-      "--destructive",
       "--chart-1",
     ]) {
       expect(palette[forbidden]).toBeUndefined();
     }
+  });
+
+  it("defaults --destructive to the standard red when not overridden", () => {
+    const palette = deriveWorkspacePalette(FULL)!;
+    expect(palette["--destructive"]).toBe("0 72% 51%");
+  });
+
+  it("applies curated core-palette overrides when set", () => {
+    const base = deriveWorkspacePalette(FULL)!;
+    const palette = deriveWorkspacePalette({
+      ...FULL,
+      brand_ring: "#22d3ee",
+      brand_destructive: "#ef4444",
+    })!;
+    // set of keys is unchanged (overrides reuse existing slots)
+    expect(new Set(Object.keys(palette))).toEqual(new Set(WORKSPACE_THEME_VAR_NAMES));
+    // overrides win over the derived defaults
+    expect(palette["--ring"]).not.toBe(base["--ring"]);
+    expect(palette["--destructive"]).not.toBe("0 72% 51%");
+  });
+
+  it("ignores malformed override hex (falls back to derived)", () => {
+    const base = deriveWorkspacePalette(FULL)!;
+    const palette = deriveWorkspacePalette({ ...FULL, brand_ring: "nope", brand_border: "" })!;
+    expect(palette["--ring"]).toBe(base["--ring"]);
+    expect(palette["--border"]).toBe(base["--border"]);
   });
 
   it("falls back to primary/background when secondary + surface are absent", () => {

--- a/frontend/src/lib/workspace-theme.ts
+++ b/frontend/src/lib/workspace-theme.ts
@@ -16,9 +16,11 @@
  * band to keep the (light) foreground readable; accents are clamped into a
  * usable band and their on-accent foreground is contrast-picked (WCAG).
  *
- * Semantic tokens are deliberately NOT overridden — OW role colours
- * (`--aqt-tank/-damage/-support`), status hues (`--aqt-emerald/-amber/-gold`),
- * chart colours and `--destructive` carry meaning and must stay stable.
+ * OW role colours (`--aqt-tank/-damage/-support`), status hues
+ * (`--aqt-emerald/-amber/-gold`) and chart colours carry meaning and are never
+ * overridden. Beyond the 4 seed colours, organisers may override a curated core
+ * set (accent/foreground/muted/border/ring/destructive); an unset override
+ * simply falls back to the derived value.
  */
 import type { Workspace, WorkspaceBranding } from "@/types/workspace.types";
 
@@ -79,6 +81,8 @@ export const WORKSPACE_THEME_VAR_NAMES: readonly string[] = [
   "--border",
   "--input",
   "--ring",
+  "--destructive",
+  "--destructive-foreground",
 ];
 
 function clamp(n: number, min: number, max: number): number {
@@ -244,16 +248,36 @@ export function deriveWorkspacePalette(
   const onAccent = pickOnColorForeground(hslToRgb(accent));
   const onSecondary = pickOnColorForeground(hslToRgb(secondary));
 
+  // Curated core-palette overrides: a valid hex wins over the derived value.
+  // Surface-like tokens (accent/muted/border) are clamped into the dark band so
+  // they stay legible on the dark canvas; ring uses the accent band; foreground
+  // is used near as-given; destructive defaults to the standard red when unset.
+  const accentSurface = parseHex(branding.brand_accent);
+  const foregroundRgb = parseHex(branding.brand_foreground);
+  const mutedRgb = parseHex(branding.brand_muted);
+  const borderRgb = parseHex(branding.brand_border);
+  const ringRgb = parseHex(branding.brand_ring);
+  const destructiveRgb = parseHex(branding.brand_destructive);
+
+  const accentHsl = accentSurface ? clampBackground(rgbToHsl(accentSurface), { min: 6, max: 26 }) : mutedSurface;
+  const fgFinal = foregroundRgb ? rgbToHsl(foregroundRgb) : fg;
+  const mutedFinal = mutedRgb ? clampBackground(rgbToHsl(mutedRgb), { min: 6, max: 26 }) : mutedSurface;
+  const borderFinal = borderRgb ? clampBackground(rgbToHsl(borderRgb), { min: 6, max: 34 }) : border;
+  const ringFinal = ringRgb ? clampAccent(rgbToHsl(ringRgb)) : accent;
+  const destructive: Hsl = destructiveRgb ? clampAccent(rgbToHsl(destructiveRgb)) : { h: 0, s: 72, l: 51 };
+  const onAccentSurface = pickOnColorForeground(hslToRgb(accentHsl));
+  const onDestructive = pickOnColorForeground(hslToRgb(destructive));
+
   return {
     // ── --aqt-* (full hsl) ──
     "--aqt-bg": fullHsl(bg),
     "--aqt-bg-2": fullHsl(bg2),
     "--aqt-card": fullHsl(surface),
     "--aqt-card-2": fullHsl(card2),
-    "--aqt-border": fullHsl(border),
+    "--aqt-border": fullHsl(borderFinal),
     "--aqt-border-2": fullHsl(border2),
     "--aqt-border-3": fullHsl(border3),
-    "--aqt-fg": fullHsl(fg),
+    "--aqt-fg": fullHsl(fgFinal),
     "--aqt-fg-muted": fullHsl(fgMuted),
     "--aqt-fg-dim": fullHsl(fgDim),
     "--aqt-fg-faint": fullHsl(fgFaint),
@@ -261,22 +285,24 @@ export function deriveWorkspacePalette(
     "--aqt-violet": fullHsl(secondary),
     // ── shadcn (bare triplet) ──
     "--background": triplet(bg),
-    "--foreground": triplet(fg),
+    "--foreground": triplet(fgFinal),
     "--card": triplet(surface),
-    "--card-foreground": triplet(fg),
+    "--card-foreground": triplet(fgFinal),
     "--popover": triplet(surface),
-    "--popover-foreground": triplet(fg),
+    "--popover-foreground": triplet(fgFinal),
     "--primary": triplet(accent),
     "--primary-foreground": onAccent,
     "--secondary": triplet(secondary),
     "--secondary-foreground": onSecondary,
-    "--muted": triplet(mutedSurface),
+    "--muted": triplet(mutedFinal),
     "--muted-foreground": triplet(fgMuted),
-    "--accent": triplet(mutedSurface),
-    "--accent-foreground": triplet(fg),
-    "--border": triplet(border),
-    "--input": triplet(border),
-    "--ring": triplet(accent),
+    "--accent": triplet(accentHsl),
+    "--accent-foreground": onAccentSurface,
+    "--border": triplet(borderFinal),
+    "--input": triplet(borderFinal),
+    "--ring": triplet(ringFinal),
+    "--destructive": triplet(destructive),
+    "--destructive-foreground": onDestructive,
   };
 }
 

--- a/frontend/src/services/workspace.service.ts
+++ b/frontend/src/services/workspace.service.ts
@@ -45,6 +45,12 @@ export default class workspaceService {
       brand_secondary?: string | null;
       brand_background?: string | null;
       brand_surface?: string | null;
+      brand_accent?: string | null;
+      brand_foreground?: string | null;
+      brand_muted?: string | null;
+      brand_border?: string | null;
+      brand_ring?: string | null;
+      brand_destructive?: string | null;
       subdomain?: string | null;
       seo_title?: string | null;
       seo_description?: string | null;

--- a/frontend/src/types/workspace.types.ts
+++ b/frontend/src/types/workspace.types.ts
@@ -124,6 +124,12 @@ export interface Workspace {
   brand_secondary: string | null;
   brand_background: string | null;
   brand_surface: string | null;
+  brand_accent: string | null;
+  brand_foreground: string | null;
+  brand_muted: string | null;
+  brand_border: string | null;
+  brand_ring: string | null;
+  brand_destructive: string | null;
   subdomain: string | null;
   seo_title: string | null;
   seo_description: string | null;
@@ -136,13 +142,23 @@ export interface Workspace {
   default_division_grid_version: DivisionGridVersion | null;
 }
 
-/** The 4 organiser-controlled brand colours + master toggle. */
+/**
+ * Organiser-controlled branding: 4 seed colours (primary/secondary/background/
+ * surface) that derive the full palette, plus 6 optional core-palette overrides
+ * (accent/foreground/muted/border/ring/destructive) that win when set.
+ */
 export interface WorkspaceBranding {
   branding_enabled: boolean;
   brand_primary: string | null;
   brand_secondary: string | null;
   brand_background: string | null;
   brand_surface: string | null;
+  brand_accent?: string | null;
+  brand_foreground?: string | null;
+  brand_muted?: string | null;
+  brand_border?: string | null;
+  brand_ring?: string | null;
+  brand_destructive?: string | null;
 }
 
 export type WorkspaceSystemRole = "owner" | "admin" | "member" | "player";


### PR DESCRIPTION
## Summary

Two related bodies of work on the public-site design system and the workspace admin.

### Design system → "Editorial Tactical" (Phase C)
- **Page heroes** unified to a shared `PageHero` — a 2px teal top hairline, a masked square grid, one restrained teal glow, and a mixed-case **Onest** title with a role-spectrum accent word. Replaces the per-page multicolored (teal + rose/amber/blue) glow + hex-lattice banners across home, tournaments (list + detail), analytics, hero-compare, user profile, encounters and users.
- **Display font** Barlow Condensed → **Onest** (design-book); Barlow import removed.
- **shadcn `.dark` tokens mapped onto the OWT `--aqt-*` palette** so every shadcn component renders in-brand (primary → teal, etc.); removed a duplicate `@layer base` block and dead CSS; collapsed the `.aqt-player` scope (tokens are global).
- **`.liquid-glass`** glassmorphism cut to flat token surfaces (blur + gradient mesh → solid `--aqt-*` + hairlines).
- Migrated the site's hardcoded `hsl()/hex` colours to `--aqt-*` tokens (alpha tints → `color-mix`). Intentional literals left + documented: charts / OG images / canvas / mermaid / SVG icons / shadcn `ui/` primitives, medal-podium scales, coordinated data-viz palettes, zinc dialogs, neutral white/black scrims.

### Workspace branding & custom domains (#10)
- Branding grown from 4 seed colours to **10**: added typed nullable hex override columns (`brand_accent/foreground/muted/border/ring/destructive`) — null → derived from seeds, set → overrides. Alembic `wsbrand0002` (additive, chains off `wscustdom0001`).
- Admin workspace **edit moved from an overloaded modal to a dedicated sub-page** `/admin/workspaces/[id]` — full-page form with all 10 pickers + live preview; list "Edit" now navigates there (create + delete stay dialogs).
- **Custom domain**: step-by-step connection instructions (TXT ownership + CNAME) + **silent DNS auto-poll** every 15s while pending; the domain goes live **only once verified** (activation gated), reflected in the status badge.

## Test plan
- [x] `next build` — 0 errors / 0 warnings
- [x] `tsc --noEmit` clean (frontend)
- [x] backend schema tests — 35 pass; `ruff` clean; `alembic heads` = single `wsbrand0002`
- [x] `workspace-theme` unit tests — 17 pass
- [x] Home hero verified live via Playwright (Onest title, spectrum accent, teal primary button, OWT palette)
- [ ] Manual: workspace edit sub-page (branding pickers + preview) and custom-domain set → DNS → auto-verify (needs DB + a real domain)
- [ ] Apply migration `wsbrand0002` on a real DB (additive nullable — safe on populated table)

## Notes / scope
- Scope: public `(site)` + workspace admin. `admin`/`balancer` themes untouched (own overrides).
- Deferred: dead `.aqt-tn`/`.tn-hero` decoration in `globals.css` (interleaved with live shared classes); sidebar token dedup.
