### PR TITLE
ci: note the self-hosted runner floor next to the checkout pin

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -74,6 +74,10 @@ jobs:
 
 
     steps:
+      # checkout v5+ runs on Node 24 and needs a runner >= v2.327.1. This job is
+      # the only one on the self-hosted 'production' runner, so bumping this pin
+      # means checking that runner's version first — GitHub-hosted runners are
+      # always current, a self-hosted one is not.
       - name: Checkout
         uses: actions/checkout@v6
       - run: docker compose -f docker-compose.production.yml --project-name owt build


### PR DESCRIPTION
Documents why bumping the `actions/checkout` pin in the deploy job needs a look at the self-hosted runner version first.

Also serves as the CI run that exercises `actions/checkout@v6` and `actions/upload-artifact@v7` on develop — pushes to develop trigger no workflows, only `pull_request` does.