### PR TITLE
Release automation: a pushed tag builds, deploys and publishes the notes

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,16 +1,21 @@
 name: Deploy to Production
 
 on:
-  release:
-    types:
-      - published
+  # Pushing a version tag IS the release. The GitHub Release object is created
+  # at the end of this workflow, from the commit log, so "released" means
+  # "built, migrated and running in production" rather than "somebody clicked
+  # publish". A `release: published` trigger would also double-fire here: the
+  # release UI creates the tag, and that is already this push.
+  push:
+    tags:
+      - "v*"
   # Redeploy or roll back to any tag that was ever built, without cutting a new
   # release. The images are immutable and live in GHCR, so this is a pull, not
   # a rebuild.
   workflow_dispatch:
     inputs:
       tag:
-        description: "Git tag / image tag to deploy (defaults to the latest release)"
+        description: "Git tag / image tag to deploy (defaults to the pushed tag)"
         required: false
         type: string
       skip_build:
@@ -26,7 +31,8 @@ on:
 # wheel) could fail the whole deploy. Nothing here runs on a self-hosted runner.
 #
 # Three paths, one workflow:
-#   release published        -> gates, build every image, deploy that tag
+#   push a v* tag            -> gates, build every image, deploy it, publish the
+#                               GitHub Release with notes from the commit log
 #   dispatch with a tag      -> build and deploy it, no gates (operator's call)
 #   dispatch with skip_build -> deploy a tag whose images already exist (rollback)
 #
@@ -37,7 +43,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write # creating the GitHub Release at the end
   packages: write
 
 jobs:
@@ -48,13 +54,13 @@ jobs:
     steps:
       - id: pick
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PUSHED_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${INPUT_TAG:-$RELEASE_TAG}"
+          TAG="${INPUT_TAG:-$PUSHED_TAG}"
           if [ -z "$TAG" ]; then
-            echo "::error::no tag: publish a release or pass one to workflow_dispatch"
+            echo "::error::no tag: push a v* tag or pass one to workflow_dispatch"
             exit 1
           fi
           # A tag is a Docker image tag here as well, so it has to be one:
@@ -64,25 +70,25 @@ jobs:
           esac
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-  # Gates run for a release and only for a release: publishing one is the
-  # automatic path, so it is held to the bar a PR is held to. A manual
-  # workflow_dispatch is an operator saying "ship this tag" -- it skips them on
-  # purpose, which is also the only way to deploy while the repo's CI is red.
+  # Gates run for a tag push and only for a tag push: that is the automatic
+  # path, so it is held to the bar a PR is held to. A manual workflow_dispatch
+  # is an operator saying "ship this tag" -- it skips them on purpose, which is
+  # also the only way to deploy while the repo's CI is red.
   gate-lint-backend:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/lint-backend.yml
 
   gate-test-backend:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/test-backend.yml
     secrets: inherit
 
   gate-ci-frontend:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/ci-frontend.yml
 
   gate-ci-gateway:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/ci-gateway.yml
 
   build:
@@ -231,3 +237,37 @@ jobs:
             cat ops/deploy/remote-deploy.sh
           } | ssh -i ~/.ssh/deploy_key -o BatchMode=yes "$DEPLOY_USER@$DEPLOY_HOST" \
             'set -e; f=$(mktemp /tmp/owt-deploy.XXXXXX.sh); trap "rm -f $f" EXIT; cat > "$f"; bash "$f"'
+
+  release:
+    needs:
+      - meta
+      - deploy
+    # Last, on purpose: the Release entry means "this is what production is
+    # running", so it is written after the deploy succeeded and not before.
+    if: ${{ needs.deploy.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Notes are rendered from the commits since the previous tag, so the
+          # whole history and every tag have to be here.
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ needs.meta.outputs.tag }}
+
+      - name: Publish ${{ needs.meta.outputs.tag }}
+        env:
+          TAG: ${{ needs.meta.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          bash ops/release/changelog.sh "$TAG" > /tmp/notes.md
+          cat /tmp/notes.md >> "$GITHUB_STEP_SUMMARY"
+          # Idempotent: a re-run of a deployed tag refreshes the notes instead of
+          # failing on "release already exists".
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file /tmp/notes.md --title "$TAG"
+          else
+            gh release create "$TAG" --verify-tag --title "$TAG" --notes-file /tmp/notes.md
+          fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,15 +199,26 @@ bus + active-user counters), **RabbitMQ** (all RPC/events/jobs), **S3/MinIO** (a
 icons, match-log files). Workers that call external APIs (Discord, OverFast, Challonge, S3)
 egress through the outbound `proxy` container (xray/shadowsocks).
 
-**Releases.** `.github/workflows/deploy-production.yml` builds all ten images on
-GitHub-hosted runners, pushes them to GHCR (one runner per image, registry-backed build
-cache), then opens one ssh session to the production host that pulls the tag, runs
-`alembic upgrade head` from the *new* image while the *old* containers still serve, and
-finally recreates the stack (`make prod-up`). Nothing builds on the server and no
-self-hosted runner takes part. Publishing a GitHub release runs the four CI gates first;
-`workflow_dispatch` deploys a tag without them, and with `skip_build` it redeploys images
-that already exist — which is the rollback. The remote half is
-[`ops/deploy/remote-deploy.sh`](../ops/deploy/remote-deploy.sh), runnable by hand.
+**Releases.** Pushing a `v*` tag is the whole ritual:
+
+```bash
+git tag -a v1.2.0 -m "…" && git push origin v1.2.0
+```
+
+`.github/workflows/deploy-production.yml` then runs the four CI gates, builds all ten
+images on GitHub-hosted runners and pushes them to GHCR (one runner per image,
+registry-backed build cache), opens one ssh session to the production host that pulls the
+tag, runs `alembic upgrade head` from the *new* image while the *old* containers still
+serve, recreates the stack (`make prod-up`), and finally publishes the GitHub Release —
+notes rendered from the Conventional Commit subjects since the previous tag by
+[`ops/release/changelog.sh`](../ops/release/changelog.sh). The Release is written last on
+purpose: it means "this is what production is running", not "somebody clicked publish".
+
+Nothing builds on the server and no self-hosted runner takes part. `workflow_dispatch`
+deploys a tag without the gates (an operator's call, and the only way out while CI is
+red), and with `skip_build` it redeploys images that already exist — which is the
+rollback. The remote half is [`ops/deploy/remote-deploy.sh`](../ops/deploy/remote-deploy.sh),
+runnable by hand.
 
 ## 7. Observability
 

--- a/ops/release/changelog.sh
+++ b/ops/release/changelog.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Render release notes for a tag from the Conventional Commit subjects since the
+# previous tag. Prints markdown on stdout.
+#
+#   ops/release/changelog.sh v1.2.0            # notes for v1.2.0
+#   ops/release/changelog.sh v1.2.0 v1.1.1     # ...against an explicit base
+#
+# Why not `gh release create --generate-notes`: GitHub builds those from merged
+# PR titles, and this repository ships one `develop -> master` PR per batch, so
+# every release would read "Merge pull request #134". The commit subjects are
+# the real log, and they are already disciplined (`type(scope): subject`).
+#
+# Merge commits are skipped for the same reason. A `!` after the type (or a
+# `BREAKING CHANGE:` trailer) promotes the commit to its own section at the top,
+# which is the one thing a reader must not scroll past.
+
+set -euo pipefail
+
+TAG="${1:?usage: changelog.sh <tag> [previous-tag]}"
+PREV="${2:-}"
+
+if [ -z "$PREV" ]; then
+    # The tag before this one on the same history. Absent (first release ever)
+    # means "everything", so the range degrades to the root commit.
+    PREV="$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)"
+fi
+RANGE="${PREV:+${PREV}..}${TAG}"
+
+REPO_URL="$(git config --get remote.origin.url | sed -e 's/\.git$//' -e 's#git@github.com:#https://github.com/#')"
+
+# %x1f between fields, %x1e between records: commit subjects contain everything
+# else, including newlines once a body sneaks in.
+LOG="$(git log --no-merges --reverse --pretty=format:'%h%x1f%s%x1f%b%x1e' "$RANGE")"
+
+render() {
+    local heading="$1" pattern="$2" body
+    body="$(printf '%s' "$LOG" | awk -v RS='\x1e' -v FS='\x1f' -v pat="$pattern" -v repo="$REPO_URL" '
+        {
+            # git separates records with a newline of its own, so every field
+            # after the first record carries it into the sha.
+            sha = $1; gsub(/^[\r\n]+|[\r\n]+$/, "", sha)
+            if (sha == "") next
+            subject = $2
+            # Dependabot does not speak Conventional Commit; its subjects start
+            # with an arrow. They are real changes and get their own section
+            # rather than being lumped in with hand-written chores.
+            if (index(subject, "⬆") == 1) { if (pat != "DEPS") next }
+            else if (pat == "DEPS") next
+            if (pat == "DEPS") {
+                printf "- %s ([%s](%s/commit/%s))\n", substr(subject, index(subject, " ") + 1), sha, repo, sha
+                next
+            }
+            # type(scope)!: subject  ->  type, scope, subject
+            if (match(subject, /^[a-z]+(\([^)]*\))?!?: /) == 0) next
+            head = substr(subject, 1, RLENGTH - 2)
+            text = substr(subject, RLENGTH + 1)
+            breaking = (index(head, "!") > 0) || (index($3, "BREAKING CHANGE") > 0)
+            type = head
+            scope = ""
+            if (match(type, /\(/)) {
+                scope = substr(type, RSTART + 1, index(type, ")") - RSTART - 1)
+                type = substr(type, 1, RSTART - 1)
+            }
+            sub(/!$/, "", type)
+            if (pat == "BREAKING") { if (!breaking) next }
+            else {
+                if (breaking) next
+                if (type !~ pat) next
+            }
+            printf "- %s%s ([%s](%s/commit/%s))\n", (scope == "" ? "" : "**" scope "**: "), text, sha, repo, sha
+        }
+    ')"
+    [ -n "$body" ] || return 0
+    printf '### %s\n\n%s\n\n' "$heading" "$body"
+}
+
+# Order is "what does this change for someone using the site", not alphabetical.
+render "⚠ Breaking" "BREAKING"
+render "Features" "^feat$"
+render "Fixes" "^fix$"
+render "Performance" "^perf$"
+render "Build & CI" "^(ci|build)$"
+render "Docs" "^docs$"
+render "Internals" "^(refactor|style|test|chore)$"
+render "Dependencies" "DEPS"
+
+# Anything whose subject is neither a Conventional Commit nor a bump still has
+# to appear — silently dropping a commit from the notes is worse than an untidy
+# heading.
+OTHER="$(printf '%s' "$LOG" | awk -v RS='\x1e' -v FS='\x1f' -v repo="$REPO_URL" '
+    {
+        sha = $1; gsub(/^[\r\n]+|[\r\n]+$/, "", sha)
+        if (sha == "") next
+        if (index($2, "⬆") == 1) next
+        if ($2 ~ /^[a-z]+(\([^)]*\))?!?: /) next
+        printf "- %s ([%s](%s/commit/%s))\n", $2, sha, repo, sha
+    }
+')"
+[ -n "$OTHER" ] && printf '### Other\n\n%s\n\n' "$OTHER"
+
+if [ -n "$PREV" ]; then
+    printf '**Full diff:** [%s...%s](%s/compare/%s...%s)\n' "$PREV" "$TAG" "$REPO_URL" "$PREV" "$TAG"
+fi


### PR DESCRIPTION
Follow-up to #134. Trigger moves from `release: published` to a `v*` tag push, and the GitHub Release is created at the END of the run — after the deploy succeeded — with notes rendered from the Conventional Commit subjects since the previous tag (`ops/release/changelog.sh`).

`gh release create --generate-notes` was the alternative and is useless here: it lists merged PR titles, and this repo ships one `develop -> master` PR per batch, so every release would read "Merge pull request #134".