### PR TITLE
fix(mix-balancer): stop building the search kernel for the build machine's CPU

### DIFF
--- a/backend/balancer-service/native/mix_balancer/CMakeLists.txt
+++ b/backend/balancer-service/native/mix_balancer/CMakeLists.txt
@@ -42,11 +42,23 @@ if(NOT MSVC)
     target_link_libraries(_core PRIVATE stdc++)
 endif()
 
+# The ISA this module is allowed to use. NOT ``native``: the release images are
+# built on a GitHub runner and run on whatever the production host is, and those
+# are different machines. ``-march=native`` on an AVX-512 Ice Lake runner emitted
+# EVEX ``vmovdqu64 %zmm0`` into ``_core.so``; importing it on the production AMD
+# EPYC-Rome (Zen 2, no AVX-512) raised SIGILL, which killed the whole worker the
+# first time a mix was balanced and took every balancer RPC down with it.
+#
+# ``x86-64-v2`` (SSE4.2 + POPCNT, everything since 2009) is the floor that still
+# gives the search's hot loop a hardware popcount for its bit iteration. Override
+# for a machine-specific build: ``-DMIX_BALANCER_ARCH=native``.
+set(MIX_BALANCER_ARCH "x86-64-v2" CACHE STRING "-march= value for the search kernel")
+
 # Set compile flags for optimization
 if(MSVC)
     target_compile_options(_core PRIVATE /O2 /Oi /Ot /GL)
 else()
-    target_compile_options(_core PRIVATE -O3 -march=native)
+    target_compile_options(_core PRIVATE -O3 -march=${MIX_BALANCER_ARCH})
 endif()
 
 # NOTE: LTO deliberately NOT enabled. Upstream had it on twice over (a


### PR DESCRIPTION
`-march=native` in `native/mix_balancer/CMakeLists.txt` compiled `_core.so` for the GitHub runner that built the release. The v1.5.0 runner had AVX-512 — the module carries EVEX `vmovdqu64 %zmm0` — and production is an AMD EPYC-Rome (Zen 2, no AVX-512), so importing it raises SIGILL.

The import is lazy, on the first mix balance, so balancer-svc died with exit 132 the moment a mix was balanced, Docker restarted it on a 60s backoff, the RPC was redelivered, and it died again: **every balancer and mix route answered 504** while the loop ran (24 restarts).

Pinned to `x86-64-v2` (SSE4.2 + POPCNT, universal since 2009 — what the bit-iteration hot loop wants). `-DMIX_BALANCER_ARCH=native` remains for machine-local builds.

Verified on the production CPU: v1.5.0's image exits 132 at import; the same sources rebuilt with this flag import and return balances.